### PR TITLE
dragonboard-410c: recommend wifi modules

### DIFF
--- a/conf/machine/dragonboard-410c.conf
+++ b/conf/machine/dragonboard-410c.conf
@@ -32,6 +32,7 @@ KERNEL_DEVICETREE = "${S}/arch/arm64/boot/dts/dragonboard.dts"
 SERIAL_CONSOLE = "115200 ttyMSM0"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += "linux-firmware \
+                                        ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'kernel-module-wcn36xx kernel-module-wcn36xx-platform', '', d)} \
                                         ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \
                                         ${@'firmware-qcom-dragonboard410c' if d.getVar('ACCEPT_QCOM_EULA', True) == '1' else ''}"
 


### PR DESCRIPTION
This makes wifi work out of the box:

root@dragonboard-410c:~# dmesg | grep wcn | grep -v Cap
[    0.224776] irq: no irq domain found for /soc/wcnss-smp2p/slave-kernel !
[    2.074374]  remoteproc0: Direct firmware load for wcnss.mdt failed with error -2
[    4.953539] wcnss: IRIS Reg: 0x51120004
[    5.165072]  remoteproc0: Booting fw image wcnss.mdt, size 7260
[    8.576187] wcnss: received WCNSS_CBC_COMPLETE_IND from FW
[    8.577049] wcn36xx-msm a000000.qcom,wcn36xx: wcn36xx_msm_probe initialized
[    8.596453] wcn36xx wcn36xx: Direct firmware load for wlan/macaddr0 failed with error -2
[    8.596545] wcn36xx wcn36xx: Failed (-2) to read macaddressfile wlan/macaddr0, using a random address instead
[    8.606677] wcn36xx: mac address: 00:0a:f5:3e:dd:52
[    9.019923] wcn36xx: firmware WLAN version 'WCN v2.0 RadioPhy vRhea_GF_1.12 with 19.2MHz XO' and CRM version 'CNSS-PR-2-0-1-2-c1-00010'
[    9.020020] wcn36xx: firmware API 1.5.1.2, 41 stations, 2 bssids
[   48.928342] wcn36xx: ERROR SMD_EVENT (259) not supported
[  112.929315] wcn36xx: ERROR SMD_EVENT (259) not supported

After configuring connman:

root@dragonboard-410c:~# ip a
1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue
    link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
    inet 127.0.0.1/8 scope host lo
       valid_lft forever preferred_lft forever
    inet6 ::1/128 scope host
       valid_lft forever preferred_lft forever
2: sit0@NONE: <NOARP> mtu 1480 qdisc noop
    link/sit 0.0.0.0 brd 0.0.0.0
3: wlan0: <BROADCAST,MULTICAST,UP,LOWER_UP8000> mtu 1500 qdisc mq qlen 1000
    link/ether 00:0a:f5:3e:dd:52 brd ff:ff:ff:ff:ff:ff
    inet 172.20.0.139/24 brd 172.20.0.255 scope global wlan0
       valid_lft forever preferred_lft forever
    inet6 fe80::20a:f5ff:fe3e:dd52/64 scope link
       valid_lft forever preferred_lft forever

Signed-off-by: Koen Kooi <koen@dominion.thruhere.net>
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>
                                                                                                                                                                           
