### PR TITLE
skales-native: depend on -native recipes for python & dtc

### DIFF
--- a/recipes-devtools/skales/skales_git.bb
+++ b/recipes-devtools/skales/skales_git.bb
@@ -8,8 +8,6 @@ LIC_FILES_CHKSUM = "file://mkbootimg;beginline=3;endline=29;md5=114b84083e657f38
 
 DEPENDS = "python dtc"
 
-inherit native
-
 SRCREV = "15ece94f09f534105f28c944d0030f8953e8267f"
 PV = "0.1+git${SRCPV}"
 
@@ -22,3 +20,5 @@ do_install () {
     install -m 0755 ${S}/mkbootimg ${D}${bindir}
     install -m 0755 ${S}/dtbTool ${D}${bindir}
 }
+
+BBCLASSEXTEND = "native"


### PR DESCRIPTION
This fixes a build error I ran into testing jethro on the dragonboard.

dtbTool (provided by skales) uses dtc. The skales recipe depends on dtc, but not the native version. If dtc-native is not built/installed to the sysroot before virtual/kernel deploy is run, the build fails. Since skales is a native recipe, it seems correct to use -native deps.

I reproduced the error by simply running the deploy recipe from a clean state. 'bitbake -c deploy virtual/kernel'