### PR TITLE
firmware-qcom-dragonboard410c: add missing dependency

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-dragonboard410c_1.3.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard410c_1.3.0.bb
@@ -8,6 +8,7 @@ SRC_URI[md5sum] = "3bcec6fa4068f4622c65a9b2e0b67f1f"
 SRC_URI[sha256sum] = "0f74c25f5c17c528a75138ad08722c835feb4cd7edac8fcafb9746481b8bdc44"
 
 DEPENDS += "mtools-native"
+do_unpack[depends] += "bc-native:do_populate_sysroot"
 
 COMPATIBLE_MACHINE = "(dragonboard-410c)"
 PACKAGE_ARCH = "${MACHINE_ARCH}"


### PR DESCRIPTION
The self-extraction shell script for the firmware uses the 'bc' command.  I ran into a failure on a build server that happened to not have that utility installed already.  Adding the dependency takes are of it.