### PR TITLE
Lk bootloader builds

### DIFF
--- a/recipes-bsp/lk/lk-linaro-qcomlt_git.bb
+++ b/recipes-bsp/lk/lk-linaro-qcomlt_git.bb
@@ -1,0 +1,47 @@
+DESCRIPTION = "Little Kernel bootloader for MSM platforms"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=5a1abdab641eec675725c843f43f03af"
+
+SRC_URI = "git://${LK_GIT_REPO};branch=${SRCBRANCH}"
+LK_GIT_REPO ??= "git.linaro.org/landing-teams/working/qualcomm/lk.git;protocol=http"
+SRCBRANCH = "release/LA.BR.1.2.4-00310-8x16.0"
+SRCREV = "2740fc8aeb78bb2e012f63f6d500f3133139c504"
+PV = "1.2.4-00310+${SRCPV}"
+
+COMPATIBLE_MACHINE = "(dragonboard-410c)"
+MAKE_TARGET = ""
+MAKE_ARGS = ""
+MAKE_TARGET_dragonboard-410c = "msm8916"
+MAKE_ARGS_dragonboard-410c = "EMMC_BOOT=1"
+
+EXTRA_OEMAKE = "${MAKE_TARGET} ${MAKE_ARGS} TOOLCHAIN_PREFIX=arm-none-eabi- NOECHO="
+
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+PROVIDES = "virtual/bootloader"
+
+S = "${WORKDIR}/git"
+
+inherit deploy
+
+INHIBIT_DEFAULT_DEPS = "1"
+DEPENDS = "gcc-cross-arm-none-eabi gcc-runtime-arm-none-eabi binutils-cross-arm-none-eabi"
+
+STAGING_BINDIR_TOOLCHAIN = "${STAGING_DIR_NATIVE}${bindir_native}/arm-none-eabi"
+LD = "arm-none-eabi-ld ${TOOLCHAIN_OPTIONS}"
+
+LK_BINARY ?= "emmc_appsboot-${PV}-${PR}.mbn"
+LK_SYMLINK ?= "emmc_appsboot.mbn"
+
+do_compile () {
+    LIBGCC=`arm-none-eabi-gcc ${TOOLCHAIN_OPTIONS} -print-libgcc-file-name`
+    oe_runmake LIBGCC="$LIBGCC"
+}
+
+do_deploy() {
+    install -d ${DEPLOYDIR}
+    install ${B}/build-msm8916/emmc_appsboot.mbn ${DEPLOYDIR}/${LK_BINARY}
+    ln -sf ${LK_BINARY} ${DEPLOYDIR}/${LK_SYMLINK}
+}
+
+addtask deploy before do_build after do_compile

--- a/recipes-core/packagegroups/packagegroup-core-standalone-sdk-target.bbappend
+++ b/recipes-core/packagegroups/packagegroup-core-standalone-sdk-target.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS_${PN} += "gcc-runtime-arm-none-eabi-dev"

--- a/recipes-core/packagegroups/packagegroup-cross-canadian.bbappend
+++ b/recipes-core/packagegroups/packagegroup-cross-canadian.bbappend
@@ -1,0 +1,1 @@
+RDEPENDS_${PN} += "binutils-cross-canadian-arm-none-eabi gcc-cross-canadian-arm-none-eabi"

--- a/recipes-devtools/binutils/binutils-cross-arm-none-eabi_2.27.bb
+++ b/recipes-devtools/binutils/binutils-cross-arm-none-eabi_2.27.bb
@@ -1,0 +1,13 @@
+require recipes-devtools/binutils/binutils.inc
+require recipes-devtools/binutils/binutils-${PV}.inc
+require recipes-devtools/binutils/binutils-cross.inc
+
+FILESEXTRAPATHS_prepend := "${COREBASE}/meta/recipes-devtools/binutils/binutils:"
+
+PROVIDES = ""
+PN = "binutils-cross-arm-none-eabi"
+TARGET_ARCH = "arm"
+TARGET_VENDOR = "-none"
+TARGET_VENDOR_virtclass-multilib-lib32 = "-none"
+TARGET_OS = "eabi"
+

--- a/recipes-devtools/binutils/binutils-cross-canadian-arm-none-eabi_2.27.bb
+++ b/recipes-devtools/binutils/binutils-cross-canadian-arm-none-eabi_2.27.bb
@@ -1,0 +1,44 @@
+require recipes-devtools/binutils/binutils.inc
+require recipes-devtools/binutils/binutils-${PV}.inc
+
+inherit cross-canadian
+
+SUMMARY = "GNU binary utilities (cross-canadian for arm-none-eabi target)"
+PN = "binutils-cross-canadian-arm-none-eabi"
+BPN = "binutils"
+
+REAL_TARGET_VENDOR := "${TARGET_VENDOR}"
+REAL_TARGET_OS := "${TARGET_OS}"
+DEPENDS = "flex-native bison-native virtual/${HOST_PREFIX}gcc-crosssdk virtual/nativesdk-libc nativesdk-zlib nativesdk-gettext nativesdk-flex"
+EXTRA_OECONF += "--with-sysroot=${SDKPATH}/sysroots/${TUNE_PKGARCH}${REAL_TARGET_VENDOR}-${REAL_TARGET_OS} \
+                "
+
+FILESEXTRAPATHS_prepend := "${COREBASE}/meta/recipes-devtools/binutils/binutils:"
+
+PROVIDES = ""
+TARGET_ARCH = "arm"
+TARGET_VENDOR = "-none"
+TARGET_VENDOR_virtclass-multilib-lib32 = "-none"
+TARGET_OS = "eabi"
+MODIFYTOS = "0"
+
+# We have to point binutils at a sysroot but we don't need to rebuild if this changes
+# e.g. we switch between different machines with different tunes.
+EXTRA_OECONF[vardepsexclude] = "TUNE_PKGARCH"
+
+do_install () {
+	autotools_do_install
+
+	# We're not interested in the libs or headers, these would come from the
+	# nativesdk or target version of the binutils recipe
+	rm -rf ${D}${prefix}/${TARGET_SYS}
+	rm -f ${D}${libdir}/libbfd*
+	rm -f ${D}${libdir}/libiberty*
+	rm -f ${D}${libdir}/libopcodes*
+	rm -f ${D}${includedir}/*.h
+
+	cross_canadian_bindirlinks
+
+}
+
+BBCLASSEXTEND = ""

--- a/recipes-devtools/gcc/gcc-arm-none-eabi.inc
+++ b/recipes-devtools/gcc/gcc-arm-none-eabi.inc
@@ -1,0 +1,8 @@
+TARGET_ARCH = "arm"
+TARGET_VENDOR = "-none"
+TARGET_VENDOR_virtclass-multilib-lib32 = "-none"
+TARGET_OS = "eabi"
+EXTRA_OECONF += "--without-headers"
+EXTRA_OECONF_remove = "--enable-threads=posix"
+EXTRA_OECONF_remove = "--enable-clocale=gnu"
+PROVIDES = ""

--- a/recipes-devtools/gcc/gcc-cross-arm-none-eabi_5.4.bb
+++ b/recipes-devtools/gcc/gcc-cross-arm-none-eabi_5.4.bb
@@ -1,0 +1,13 @@
+require recipes-devtools/gcc/gcc-${PV}.inc
+require recipes-devtools/gcc/gcc-cross.inc
+require gcc-arm-none-eabi.inc
+
+PN = "gcc-cross-arm-none-eabi"
+PROVIDES = "${PN}"
+DEPENDS = "binutils-cross-arm-none-eabi ${NATIVEDEPS}"
+
+EXTRA_OEMAKE += "inhibit_libc=true"
+
+do_install_append() {
+	hardlinkdir . ${D}${includedir}/gcc-build-internal-${TARGET_SYS}
+}

--- a/recipes-devtools/gcc/gcc-cross-canadian-arm-none-eabi_5.4.bb
+++ b/recipes-devtools/gcc/gcc-cross-canadian-arm-none-eabi_5.4.bb
@@ -1,0 +1,18 @@
+require recipes-devtools/gcc/gcc-${PV}.inc
+require recipes-devtools/gcc/gcc-cross-canadian.inc
+
+SUMMARY = "GNU cc and gcc C compilers (cross-canadian for arm-none-eabi target)"
+PN = "gcc-cross-canadian-arm-none-eabi"
+
+DEPENDS = "virtual/${HOST_PREFIX}gcc-crosssdk virtual/${HOST_PREFIX}binutils-crosssdk virtual/nativesdk-${HOST_PREFIX}libc-for-gcc nativesdk-gettext \
+           gcc-cross-arm-none-eabi binutils-cross-canadian-arm-none-eabi"
+
+GCCMULTILIB = ""
+
+require gcc-arm-none-eabi.inc
+
+MODIFYTOS = "0"
+
+PROVIDES = "${PN}"
+
+EXTRA_OEMAKE += "inhibit_libc=true"

--- a/recipes-devtools/gcc/gcc-runtime-arm-none-eabi_5.4.bb
+++ b/recipes-devtools/gcc/gcc-runtime-arm-none-eabi_5.4.bb
@@ -1,0 +1,25 @@
+require recipes-devtools/gcc/gcc-${PV}.inc
+require recipes-devtools/gcc/gcc-runtime.inc
+ORIG_TARGET_ARCH := "${TARGET_ARCH}"
+ORIG_TUNE_FEATURES := "${TUNE_FEATURES}"
+require gcc-arm-none-eabi.inc
+
+# Need to set DPKG_ARCH to match the real target architecture, so
+# dpkg can find it (e.g., for SDK construction).
+DPKG_ARCH = "${@debian_arch_map(d.getVar('ORIG_TARGET_ARCH', True), d.getVar('ORIG_TUNE_FEATURES', True))}"
+
+RUNTIMETARGET = "libgcc"
+
+DEPENDS = "gcc-cross-arm-none-eabi"
+PN = "gcc-runtime-arm-none-eabi"
+
+do_install_append() {
+	# Hoist libgcc up into the directory where the compiler will look for it
+	mv ${D}${libdir}/gcc/${TARGET_SYS} ${D}${libdir}/
+	rmdir ${D}${libdir}/gcc
+}
+
+PACKAGES = "${PN}-dev"
+FILES_${PN}-dev = "${libdir}/${TARGET_SYS}"
+RDEPENDS_${PN}-dev = ""
+INSANE_SKIP_${PN}-dev = "staticdev"


### PR DESCRIPTION
This patch series is for building the lk bootloader for the dragonboard-410c, along with the toolchain pieces required to get that build to work.

If accepted, I'll submit a further pull request to bring in the rest of the bits needed to build a complete fastboot-able set of binaries for complete initialization of the Dragonboard's eMMC.
