### PR TITLE
Replace overrides in kernel recipes with machine/SoC settings

### DIFF
--- a/conf/machine/dragonboard-410c.conf
+++ b/conf/machine/dragonboard-410c.conf
@@ -6,7 +6,6 @@ require conf/machine/include/qcom-apq8016.inc
 
 MACHINE_FEATURES = "usbhost usbgadget alsa screen wifi bluetooth ext2"
 
-KERNEL_IMAGETYPE = "Image"
 KERNEL_DEVICETREE = "qcom/apq8016-sbc.dtb"
 
 SERIAL_CONSOLE = "115200 ttyMSM0"
@@ -19,4 +18,4 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     ${@'firmware-qcom-dragonboard410c' if d.getVar('ACCEPT_EULA_dragonboard-410c', True) == '1' else ''} \
 "
 
-CMDLINE = "console=ttyMSM0,115200n8 root=/dev/mmcblk0p10 rootwait"
+BOOTIMG_CMDLINE_ROOT ?= "root=/dev/mmcblk0p10 rootwait"

--- a/conf/machine/dragonboard-820c.conf
+++ b/conf/machine/dragonboard-820c.conf
@@ -15,7 +15,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     kernel-modules \
 "
 
-CMDLINE = "console=ttyMSM0,115200n8 root=/dev/sde18 rootwait"
+BOOTIMG_CMDLINE_ROOT ?= "root=/dev/sde18 rootwait"
 
 # UFS partitions setup with 4096 logical sector size
 EXTRA_IMAGECMD_ext4 += " -b 4096 "

--- a/conf/machine/ifc6410.conf
+++ b/conf/machine/ifc6410.conf
@@ -12,9 +12,10 @@ MACHINE_EXTRA_RRECOMMENDS = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \
 "
 
-KERNEL_IMAGETYPE = "zImage"
 KERNEL_DEVICETREE = "qcom-apq8064-ifc6410.dtb"
 
 SERIAL_CONSOLE = "115200 ttyMSM0"
+
+BOOTIMG_CMDLINE_ROOT ?= "root=/dev/mmcblk0p12 rootwait"
 
 INHERIT += "qcom-firmware-mount"

--- a/conf/machine/include/qcom-apq8016.inc
+++ b/conf/machine/include/qcom-apq8016.inc
@@ -25,6 +25,14 @@ PREFERRED_PROVIDER_virtual/libgles2 ?= "mesa"
 PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-linaro-qcomlt"
 
+KERNEL_DEFCONFIG ?= "${S}/arch/arm64/configs/defconfig"
+KERNEL_IMAGETYPE = "Image"
+
+BOOTIMG_PAGE_SIZE ?= "2048"
+BOOTIMG_BASE_ADDR ?= "0x80000000"
+DT_IMAGE_BASE_NAME ?= "dt-${KERNEL_IMAGE_BASE_NAME}"
+DT_IMAGE_SYMLINK_NAME ?= "dt-${KERNEL_IMAGE_SYMLINK_NAME}"
+
 # Fastboot expects an ext4 image, which needs to be 4096 aligned
 IMAGE_FSTYPES_append = " ext4.gz"
 IMAGE_ROOTFS_ALIGNMENT = "4096"

--- a/conf/machine/include/qcom-apq8064.inc
+++ b/conf/machine/include/qcom-apq8064.inc
@@ -23,6 +23,14 @@ PREFERRED_PROVIDER_virtual/libgles2 ?= "mesa"
 PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"
 PREFERRED_PROVIDER_virtual/kernel = "linux-linaro-qcomlt"
 
+KERNEL_DEFCONFIG ?= "${S}/arch/arm/configs/qcom_defconfig"
+KERNEL_IMAGETYPE = "zImage"
+
+BOOTIMG_PAGE_SIZE ?= "2048"
+BOOTIMG_BASE_ADDR ?= "0x80200000"
+DT_IMAGE_BASE_NAME ?= ""
+DT_IMAGE_SYMLINK_NAME ?= ""
+
 # Fastboot expects an ext4 image, which needs to be 4096 aligned
 IMAGE_FSTYPES_append = " ext4.gz"
 IMAGE_ROOTFS_ALIGNMENT = "4096"

--- a/conf/machine/include/qcom-apq8096.inc
+++ b/conf/machine/include/qcom-apq8096.inc
@@ -9,6 +9,14 @@ PREFERRED_PROVIDER_virtual/libgles2 ?= "mesa"
 PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-linaro-qcomlt-tracking"
 
+KERNEL_DEFCONFIG ?= "${S}/arch/arm64/configs/defconfig"
+KERNEL_IMAGETYPE = "Image"
+
+BOOTIMG_PAGE_SIZE ?= "2048"
+BOOTIMG_BASE_ADDR ?= "0x80000000"
+DT_IMAGE_BASE_NAME ?= "dt-${KERNEL_IMAGE_BASE_NAME}"
+DT_IMAGE_SYMLINK_NAME ?= "dt-${KERNEL_IMAGE_SYMLINK_NAME}"
+
 # Fastboot expects an ext4 image, which needs to be 4096 aligned
 IMAGE_FSTYPES_append = " ext4.gz"
 IMAGE_ROOTFS_ALIGNMENT = "4096"

--- a/conf/machine/sd-600eval.conf
+++ b/conf/machine/sd-600eval.conf
@@ -14,7 +14,8 @@ MACHINE_EXTRA_RRECOMMENDS = " \
     firmware-qcom-sd-600eval \
 "
 
-KERNEL_IMAGETYPE = "zImage"
 KERNEL_DEVICETREE = "qcom-apq8064-arrow-sd-600eval.dtb"
 
 SERIAL_CONSOLE = "115200 ttyMSM0"
+
+BOOTIMG_CMDLINE_ROOT ?= "root=/dev/mmcblk0p12 rootwait"

--- a/recipes-kernel/linux/linux-linaro-qcomlt-tracking_4.6.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-tracking_4.6.bb
@@ -11,11 +11,10 @@ LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "integration-linux-qcomlt"
 SRCREV ?= "5574089362de2fb0ebbc0c4d9bd48203b59b7b1b"
 SRC_URI = "${LINUX_LINARO_QCOM_GIT};nobranch=1"
+PV .= "+git${SRCPV}"
 
 COMPATIBLE_MACHINE = "(apq8064|apq8016|apq8096)"
 
-KERNEL_DEFCONFIG_aarch64 ?= "${S}/arch/arm64/configs/defconfig"
-KERNEL_DEFCONFIG_apq8064 ?= "${S}/arch/arm/configs/qcom_defconfig"
 KERNEL_CONFIG_FRAGMENTS += "${S}/kernel/configs/distro.config"
 
 # append DTB, since bootloader doesn't support DTB
@@ -30,8 +29,3 @@ do_compile_append_apq8064() {
 
 # Wifi firmware has a recognizable arch :(
 ERROR_QA_remove = "arch"
-
-QCOM_BOOTIMG_ROOTFS_dragonboard-410c = "mmcblk0p10"
-QCOM_BOOTIMG_ROOTFS_dragonboard-820c = "sde18"
-QCOM_BOOTIMG_ROOTFS_ifc6410 = "mmcblk0p12"
-QCOM_BOOTIMG_ROOTFS_sd-600eval = "mmcblk0p12"

--- a/recipes-kernel/linux/linux-linaro-qcomlt_4.4.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_4.4.bb
@@ -10,11 +10,10 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "release/qcomlt-4.4"
 SRCREV ?= "40e98b46d2d547c44ad1d0a0125cf4c6f963a3d4"
+PV .= "+git${SRCPV}"
 
 COMPATIBLE_MACHINE = "(ifc6410|sd-600eval|dragonboard-410c)"
 
-KERNEL_DEFCONFIG_aarch64 ?= "${S}/arch/arm64/configs/defconfig"
-KERNEL_DEFCONFIG_apq8064 ?= "${S}/arch/arm/configs/qcom_defconfig"
 KERNEL_CONFIG_FRAGMENTS += "${S}/kernel/configs/distro.config"
 
 # append DTB, since bootloader doesn't support DTB
@@ -29,7 +28,3 @@ do_compile_append_apq8064() {
 
 # Wifi firmware has a recognizable arch :( 
 ERROR_QA_remove = "arch"
-
-QCOM_BOOTIMG_ROOTFS_dragonboard-410c = "mmcblk0p10"
-QCOM_BOOTIMG_ROOTFS_ifc6410 = "mmcblk0p12"
-QCOM_BOOTIMG_ROOTFS_sd-600eval = "mmcblk0p12"

--- a/recipes-kernel/linux/linux-qcom-bootimg.inc
+++ b/recipes-kernel/linux/linux-qcom-bootimg.inc
@@ -1,64 +1,44 @@
-python __anonymous () {
-    depends = d.getVar("DEPENDS", True)
-    depends = "%s skales-native" % depends
-    d.setVar("DEPENDS", depends)
+DEPENDS += "skales-native"
+
+BOOT_IMAGE_BASE_NAME ?= "boot-${KERNEL_IMAGE_BASE_NAME}"
+BOOT_IMAGE_SYMLINK_NAME ?= "boot-${MACHINE}"
+
+python __anonymous() {
+    if d.getVar('SERIAL_CONSOLES', True):
+        consoleargs = d.getVar('SERIAL_CONSOLES', True).split()[0].split(';')
+        d.setVar('BOOTIMG_CMDLINE_CONSOLE', 'console={1},{0}n8'.format(consoleargs[0], consoleargs[1]))
+    else:
+        d.setVar('BOOTIMG_CMDLINE_CONSOLE', '')
+    if d.getVar('DT_IMAGE_BASE_NAME', True):
+        d.setVar('BOOTIMG_DT_ARG', '--dt ${DEPLOYDIR}/${DT_IMAGE_BASE_NAME}.img')
+    else:
+        d.setVar('BOOTIMG_DT_ARG', '')
 }
 
-QCOM_BOOTIMG_ROOTFS ?= "undefined"
+BOOTIMG_CMDLINE ?= "${BOOTIMG_CMDLINE_ROOT} ${BOOTIMG_CMDLINE_CONSOLE}"
 
-# set output file names
-DT_IMAGE_BASE_NAME = "dt-${PKGE}-${PKGV}-${PKGR}-${MACHINE}-${DATETIME}"
-DT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
+do_deploy() {
 
-BOOT_IMAGE_BASE_NAME = "boot-${PKGE}-${PKGV}-${PKGR}-${MACHINE}-${DATETIME}"
-BOOT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
+    kernel_do_deploy
 
-do_deploy_append_aarch64() {
-
-    dtbTool -o ${DEPLOYDIR}/${DT_IMAGE_BASE_NAME}.img -s 2048 ${B}/arch/${ARCH}/boot/dts/qcom/
-
-    tmp="${SERIAL_CONSOLES}"
-    baudrate=`echo $tmp | sed 's/\;.*//'`
-    ttydev=`echo $tmp | sed -e 's/^[0-9]*\;//' -e 's/\s.*//' -e 's/\;.*//'`
+    if [ -n "${DT_IMAGE_BASE_NAME}" ]; then
+        dtbTool -o ${DEPLOYDIR}/${DT_IMAGE_BASE_NAME}.img -s ${BOOTIMG_PAGE_SIZE} ${B}/arch/${ARCH}/boot/dts/qcom/
+    fi
 
     # mkbootimg requires an initrd file, make fake one that will be ignored
     # during boot
     echo "This is not an initrd" > ${B}/initrd.img
 
-    mkbootimg --kernel ${B}/arch/${ARCH}/boot/Image \
+    mkbootimg --kernel ${B}/arch/${ARCH}/boot/${KERNEL_IMAGETYPE} \
               --ramdisk ${B}/initrd.img \
               --output ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.img \
-              --dt ${DEPLOYDIR}/${DT_IMAGE_BASE_NAME}.img \
-              --pagesize 2048 \
-              --base 0x80000000 \
-              --cmdline \
-              "root=/dev/${QCOM_BOOTIMG_ROOTFS} rw rootwait console=${ttydev},${baudrate}n8"
+              ${BOOTIMG_DT_ARG} \
+              --pagesize ${BOOTIMG_PAGE_SIZE} \
+              --base ${BOOTIMG_BASE_ADDR} \
+              --cmdline "${BOOTIMG_CMDLINE}"
 
-    cd ${DEPLOYDIR}
-	ln -sf ${DT_IMAGE_BASE_NAME}.img dt-${MACHINE}.img
-	ln -sf ${BOOT_IMAGE_BASE_NAME}.img boot-${MACHINE}.img
-    cd -
-}
-
-do_deploy_append_apq8064 () {
-
-    tmp="${SERIAL_CONSOLES}"
-    baudrate=`echo $tmp | sed 's/\;.*//'`
-    ttydev=`echo $tmp | sed -e 's/^[0-9]*\;//' -e 's/\s.*//' -e 's/\;.*//'`
-
-    # mkbootimg requires an initrd file, make fake one that will be ignored
-    # during boot
-    echo "This is not an initrd" > ${B}/initrd.img
-
-    mkbootimg --kernel ${B}/arch/${ARCH}/boot/zImage \
-              --ramdisk ${B}/initrd.img \
-              --output ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.img \
-              --pagesize 2048 \
-              --base 0x80200000 \
-              --cmdline \
-              "root=/dev/${QCOM_BOOTIMG_ROOTFS} rw rootwait console=${ttydev},${baudrate}n8"
-
-    cd ${DEPLOYDIR}
-	ln -sf ${BOOT_IMAGE_BASE_NAME}.img boot-${MACHINE}.img
-    cd -
+    ln -sf ${BOOT_IMAGE_BASE_NAME}.img ${DEPLOYDIR}/${BOOT_IMAGE_SYMLINK_NAME}.img
+    if [ -n "${DT_IMAGE_BASE_NAME}" ]; then
+        ln -sf ${DT_IMAGE_BASE_NAME}.img ${DEPLOYDIR}/${DT_IMAGE_SYMLINK_NAME}.img
+    fi
 }


### PR DESCRIPTION
I put these changes together to make it easier to add a new target and to add bbappends to customize these recipes where needed, and to do some cleanup to eliminate redundant code and make version changes detectable at build time when SRCREV changes (by using SRCPV in PV).

I've been able to test these changes with my db410c, but couldn't test with others as I don't have the hardware.
