### PR TITLE
Kernel recipe patches v2, part 1 - reduce duplication

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcom.inc
+++ b/recipes-kernel/linux/linux-linaro-qcom.inc
@@ -17,6 +17,10 @@ SRC_URI = "${LINUX_LINARO_QCOM_GIT};branch=${SRCBRANCH}"
 
 S = "${WORKDIR}/git"
 
+KERNEL_DEFCONFIG_aarch64 ?= "${S}/arch/arm64/configs/defconfig"
+KERNEL_DEFCONFIG_apq8064 ?= "${S}/arch/arm/configs/qcom_defconfig"
+KERNEL_CONFIG_FRAGMENTS += "${S}/kernel/configs/distro.config"
+
 kernel_conf_variable() {
 	CONF_SED_SCRIPT="$CONF_SED_SCRIPT /CONFIG_$1[ =]/d;"
 	if test "$2" = "n"

--- a/recipes-kernel/linux/linux-linaro-qcom.inc
+++ b/recipes-kernel/linux/linux-linaro-qcom.inc
@@ -77,3 +77,13 @@ do_configure_prepend() {
 	yes '' | oe_runmake -C ${S} O=${B} oldconfig
         oe_runmake -C ${S} O=${B} savedefconfig && cp ${B}/defconfig ${WORKDIR}/defconfig.saved
 }
+
+# append DTB, since bootloader doesn't support DTB
+do_compile_append_apq8064() {
+    if ! [ -e ${B}/arch/${ARCH}/boot/dts/${KERNEL_DEVICETREE} ] ; then
+        oe_runmake ${KERNEL_DEVICETREE}
+    fi
+    cp arch/${ARCH}/boot/zImage arch/${ARCH}/boot/zImage.backup
+    cat arch/${ARCH}/boot/zImage.backup arch/${ARCH}/boot/dts/${KERNEL_DEVICETREE} > arch/${ARCH}/boot/zImage
+    rm -f arch/${ARCH}/boot/zImage.backup
+}

--- a/recipes-kernel/linux/linux-linaro-qcomlt-tracking_4.6.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-tracking_4.6.bb
@@ -20,8 +20,3 @@ KERNEL_CONFIG_FRAGMENTS += "${S}/kernel/configs/distro.config"
 
 # Wifi firmware has a recognizable arch :(
 ERROR_QA_remove = "arch"
-
-QCOM_BOOTIMG_ROOTFS_dragonboard-410c = "mmcblk0p10"
-QCOM_BOOTIMG_ROOTFS_dragonboard-820c = "sde18"
-QCOM_BOOTIMG_ROOTFS_ifc6410 = "mmcblk0p12"
-QCOM_BOOTIMG_ROOTFS_sd-600eval = "mmcblk0p12"

--- a/recipes-kernel/linux/linux-linaro-qcomlt-tracking_4.6.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-tracking_4.6.bb
@@ -18,16 +18,6 @@ KERNEL_DEFCONFIG_aarch64 ?= "${S}/arch/arm64/configs/defconfig"
 KERNEL_DEFCONFIG_apq8064 ?= "${S}/arch/arm/configs/qcom_defconfig"
 KERNEL_CONFIG_FRAGMENTS += "${S}/kernel/configs/distro.config"
 
-# append DTB, since bootloader doesn't support DTB
-do_compile_append_apq8064() {
-    if ! [ -e ${B}/arch/${ARCH}/boot/dts/${KERNEL_DEVICETREE} ] ; then
-        oe_runmake ${KERNEL_DEVICETREE}
-    fi
-    cp arch/${ARCH}/boot/zImage arch/${ARCH}/boot/zImage.backup
-    cat arch/${ARCH}/boot/zImage.backup arch/${ARCH}/boot/dts/${KERNEL_DEVICETREE} > arch/${ARCH}/boot/zImage
-    rm -f arch/${ARCH}/boot/zImage.backup
-}
-
 # Wifi firmware has a recognizable arch :(
 ERROR_QA_remove = "arch"
 

--- a/recipes-kernel/linux/linux-linaro-qcomlt-tracking_4.6.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-tracking_4.6.bb
@@ -14,9 +14,5 @@ SRC_URI = "${LINUX_LINARO_QCOM_GIT};nobranch=1"
 
 COMPATIBLE_MACHINE = "(apq8064|apq8016|apq8096)"
 
-KERNEL_DEFCONFIG_aarch64 ?= "${S}/arch/arm64/configs/defconfig"
-KERNEL_DEFCONFIG_apq8064 ?= "${S}/arch/arm/configs/qcom_defconfig"
-KERNEL_CONFIG_FRAGMENTS += "${S}/kernel/configs/distro.config"
-
 # Wifi firmware has a recognizable arch :(
 ERROR_QA_remove = "arch"

--- a/recipes-kernel/linux/linux-linaro-qcomlt_4.4.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_4.4.bb
@@ -17,16 +17,6 @@ KERNEL_DEFCONFIG_aarch64 ?= "${S}/arch/arm64/configs/defconfig"
 KERNEL_DEFCONFIG_apq8064 ?= "${S}/arch/arm/configs/qcom_defconfig"
 KERNEL_CONFIG_FRAGMENTS += "${S}/kernel/configs/distro.config"
 
-# append DTB, since bootloader doesn't support DTB
-do_compile_append_apq8064() {
-    if ! [ -e ${B}/arch/${ARCH}/boot/dts/${KERNEL_DEVICETREE} ] ; then
-        oe_runmake ${KERNEL_DEVICETREE}
-    fi
-    cp arch/${ARCH}/boot/zImage arch/${ARCH}/boot/zImage.backup
-    cat arch/${ARCH}/boot/zImage.backup arch/${ARCH}/boot/dts/${KERNEL_DEVICETREE} > arch/${ARCH}/boot/zImage
-    rm -f arch/${ARCH}/boot/zImage.backup
-}
-
 # Wifi firmware has a recognizable arch :( 
 ERROR_QA_remove = "arch"
 

--- a/recipes-kernel/linux/linux-linaro-qcomlt_4.4.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_4.4.bb
@@ -13,9 +13,5 @@ SRCREV ?= "40e98b46d2d547c44ad1d0a0125cf4c6f963a3d4"
 
 COMPATIBLE_MACHINE = "(ifc6410|sd-600eval|dragonboard-410c)"
 
-KERNEL_DEFCONFIG_aarch64 ?= "${S}/arch/arm64/configs/defconfig"
-KERNEL_DEFCONFIG_apq8064 ?= "${S}/arch/arm/configs/qcom_defconfig"
-KERNEL_CONFIG_FRAGMENTS += "${S}/kernel/configs/distro.config"
-
 # Wifi firmware has a recognizable arch :( 
 ERROR_QA_remove = "arch"

--- a/recipes-kernel/linux/linux-linaro-qcomlt_4.4.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_4.4.bb
@@ -19,7 +19,3 @@ KERNEL_CONFIG_FRAGMENTS += "${S}/kernel/configs/distro.config"
 
 # Wifi firmware has a recognizable arch :( 
 ERROR_QA_remove = "arch"
-
-QCOM_BOOTIMG_ROOTFS_dragonboard-410c = "mmcblk0p10"
-QCOM_BOOTIMG_ROOTFS_ifc6410 = "mmcblk0p12"
-QCOM_BOOTIMG_ROOTFS_sd-600eval = "mmcblk0p12"

--- a/recipes-kernel/linux/linux-qcom-bootimg.inc
+++ b/recipes-kernel/linux/linux-qcom-bootimg.inc
@@ -5,6 +5,10 @@ python __anonymous () {
 }
 
 QCOM_BOOTIMG_ROOTFS ?= "undefined"
+QCOM_BOOTIMG_ROOTFS_dragonboard-410c = "mmcblk0p10"
+QCOM_BOOTIMG_ROOTFS_dragonboard-820c = "sde18"
+QCOM_BOOTIMG_ROOTFS_ifc6410 = "mmcblk0p12"
+QCOM_BOOTIMG_ROOTFS_sd-600eval = "mmcblk0p12"
 
 # set output file names
 DT_IMAGE_BASE_NAME = "dt-${PKGE}-${PKGV}-${PKGR}-${MACHINE}-${DATETIME}"


### PR DESCRIPTION
Moves settings and a function _append that were duplicated across the kernel recipes into common .inc files.