### PR TITLE
Kernel recipe patches, part2 - bootimg-related patches, v2

### DIFF
--- a/conf/machine/dragonboard-410c.conf
+++ b/conf/machine/dragonboard-410c.conf
@@ -19,4 +19,6 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     ${@'firmware-qcom-dragonboard410c' if d.getVar('ACCEPT_EULA_dragonboard-410c', True) == '1' else ''} \
 "
 
+QCOM_BOOTIMG_ROOTFS ?= "mmcblk0p10"
+
 CMDLINE = "console=ttyMSM0,115200n8 root=/dev/mmcblk0p10 rootwait"

--- a/conf/machine/dragonboard-820c.conf
+++ b/conf/machine/dragonboard-820c.conf
@@ -15,6 +15,8 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     kernel-modules \
 "
 
+QCOM_BOOTIMG_ROOTFS ?= "sde18"
+
 CMDLINE = "console=ttyMSM0,115200n8 root=/dev/sde18 rootwait"
 
 # UFS partitions setup with 4096 logical sector size

--- a/conf/machine/ifc6410.conf
+++ b/conf/machine/ifc6410.conf
@@ -17,4 +17,6 @@ KERNEL_DEVICETREE = "qcom-apq8064-ifc6410.dtb"
 
 SERIAL_CONSOLE = "115200 ttyMSM0"
 
+QCOM_BOOTIMG_ROOTFS ?= "mmcblk0p12"
+
 INHERIT += "qcom-firmware-mount"

--- a/conf/machine/include/qcom-apq8016.inc
+++ b/conf/machine/include/qcom-apq8016.inc
@@ -28,3 +28,7 @@ PREFERRED_PROVIDER_virtual/kernel ?= "linux-linaro-qcomlt"
 # Fastboot expects an ext4 image, which needs to be 4096 aligned
 IMAGE_FSTYPES_append = " ext4.gz"
 IMAGE_ROOTFS_ALIGNMENT = "4096"
+
+QCOM_BOOTIMG_KERNEL_BASE ?= "0x80000000"
+QCOM_BOOTIMG_PAGE_SIZE ?= "2048"
+QCOM_BOOTIMG_BUNDLE_DT ?= "1"

--- a/conf/machine/include/qcom-apq8064.inc
+++ b/conf/machine/include/qcom-apq8064.inc
@@ -26,3 +26,7 @@ PREFERRED_PROVIDER_virtual/kernel = "linux-linaro-qcomlt"
 # Fastboot expects an ext4 image, which needs to be 4096 aligned
 IMAGE_FSTYPES_append = " ext4.gz"
 IMAGE_ROOTFS_ALIGNMENT = "4096"
+
+QCOM_BOOTIMG_KERNEL_BASE ?= "0x80200000"
+QCOM_BOOTIMG_PAGE_SIZE ?= "2048"
+QCOM_BOOTIMG_BUNDLE_DT ?= "0"

--- a/conf/machine/include/qcom-apq8096.inc
+++ b/conf/machine/include/qcom-apq8096.inc
@@ -12,3 +12,7 @@ PREFERRED_PROVIDER_virtual/kernel ?= "linux-linaro-qcomlt-tracking"
 # Fastboot expects an ext4 image, which needs to be 4096 aligned
 IMAGE_FSTYPES_append = " ext4.gz"
 IMAGE_ROOTFS_ALIGNMENT = "4096"
+
+QCOM_BOOTIMG_KERNEL_BASE ?= "0x80000000"
+QCOM_BOOTIMG_PAGE_SIZE ?= "2048"
+QCOM_BOOTIMG_BUNDLE_DT ?= "1"

--- a/conf/machine/sd-600eval.conf
+++ b/conf/machine/sd-600eval.conf
@@ -18,3 +18,5 @@ KERNEL_IMAGETYPE = "zImage"
 KERNEL_DEVICETREE = "qcom-apq8064-arrow-sd-600eval.dtb"
 
 SERIAL_CONSOLE = "115200 ttyMSM0"
+
+QCOM_BOOTIMG_ROOTFS ?= "mmcblk0p12"

--- a/recipes-kernel/linux/linux-qcom-bootimg.inc
+++ b/recipes-kernel/linux/linux-qcom-bootimg.inc
@@ -1,43 +1,18 @@
 DEPENDS += "skales-native"
 
-QCOM_BOOTIMG_ROOTFS ?= "undefined"
-QCOM_BOOTIMG_ROOTFS_dragonboard-410c = "mmcblk0p10"
-QCOM_BOOTIMG_ROOTFS_dragonboard-820c = "sde18"
-QCOM_BOOTIMG_ROOTFS_ifc6410 = "mmcblk0p12"
-QCOM_BOOTIMG_ROOTFS_sd-600eval = "mmcblk0p12"
-
 # set output file names
 DT_IMAGE_BASE_NAME = "dt-${KERNEL_IMAGE_BASE_NAME}"
 DT_IMAGE_SYMLINK_NAME = "dt-${KERNEL_IMAGE_SYMLINK_NAME}"
 BOOT_IMAGE_BASE_NAME = "boot-${KERNEL_IMAGE_BASE_NAME}"
 BOOT_IMAGE_SYMLINK_NAME = "boot-${KERNEL_IMAGE_SYMLINK_NAME}"
 
-do_deploy_append_aarch64() {
+do_deploy_append() {
 
-    dtbTool -o ${DEPLOYDIR}/${DT_IMAGE_BASE_NAME}.img -s 2048 ${B}/arch/${ARCH}/boot/dts/qcom/
-
-    tmp="${SERIAL_CONSOLES}"
-    baudrate=`echo $tmp | sed 's/\;.*//'`
-    ttydev=`echo $tmp | sed -e 's/^[0-9]*\;//' -e 's/\s.*//' -e 's/\;.*//'`
-
-    # mkbootimg requires an initrd file, make fake one that will be ignored
-    # during boot
-    echo "This is not an initrd" > ${B}/initrd.img
-
-    mkbootimg --kernel ${B}/arch/${ARCH}/boot/Image \
-              --ramdisk ${B}/initrd.img \
-              --output ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.img \
-              --dt ${DEPLOYDIR}/${DT_IMAGE_BASE_NAME}.img \
-              --pagesize 2048 \
-              --base 0x80000000 \
-              --cmdline \
-              "root=/dev/${QCOM_BOOTIMG_ROOTFS} rw rootwait console=${ttydev},${baudrate}n8"
-
-    ln -sf ${DT_IMAGE_BASE_NAME}.img ${DEPLOYDIR}/${DT_IMAGE_SYMLINK_NAME}.img
-    ln -sf ${BOOT_IMAGE_BASE_NAME}.img ${DEPLOYDIR}/${BOOT_IMAGE_SYMLINK_NAME}.img
-}
-
-do_deploy_append_apq8064 () {
+    mkbootimg_dtarg=""
+    if [ "${QCOM_BOOTIMG_BUNDLE_DT}" = "1" ]; then
+        dtbTool -o ${DEPLOYDIR}/${DT_IMAGE_BASE_NAME}.img -s ${QCOM_BOOTIMG_PAGE_SIZE} ${B}/arch/${ARCH}/boot/dts/qcom/
+        mkbootimg_dtarg="--dt ${DEPLOYDIR}/${DT_IMAGE_BASE_NAME}.img"
+    fi
 
     tmp="${SERIAL_CONSOLES}"
     baudrate=`echo $tmp | sed 's/\;.*//'`
@@ -47,13 +22,17 @@ do_deploy_append_apq8064 () {
     # during boot
     echo "This is not an initrd" > ${B}/initrd.img
 
-    mkbootimg --kernel ${B}/arch/${ARCH}/boot/zImage \
+    mkbootimg --kernel ${B}/arch/${ARCH}/boot/${KERNEL_IMAGETYPE} \
               --ramdisk ${B}/initrd.img \
               --output ${DEPLOYDIR}/${BOOT_IMAGE_BASE_NAME}.img \
-              --pagesize 2048 \
-              --base 0x80200000 \
+              $mkbootimg_dtarg \
+              --pagesize ${QCOM_BOOTIMG_PAGE_SIZE} \
+              --base ${QCOM_BOOTIMG_KERNEL_BASE} \
               --cmdline \
               "root=/dev/${QCOM_BOOTIMG_ROOTFS} rw rootwait console=${ttydev},${baudrate}n8"
 
+    if [ "${QCOM_BOOTIMG_BUNDLE_DT}" = "1" ]; then
+        ln -sf ${DT_IMAGE_BASE_NAME}.img ${DEPLOYDIR}/${DT_IMAGE_SYMLINK_NAME}.img
+    fi
     ln -sf ${BOOT_IMAGE_BASE_NAME}.img ${DEPLOYDIR}/${BOOT_IMAGE_SYMLINK_NAME}.img
 }

--- a/recipes-kernel/linux/linux-qcom-bootimg.inc
+++ b/recipes-kernel/linux/linux-qcom-bootimg.inc
@@ -1,8 +1,4 @@
-python __anonymous () {
-    depends = d.getVar("DEPENDS", True)
-    depends = "%s skales-native" % depends
-    d.setVar("DEPENDS", depends)
-}
+DEPENDS += "skales-native"
 
 QCOM_BOOTIMG_ROOTFS ?= "undefined"
 QCOM_BOOTIMG_ROOTFS_dragonboard-410c = "mmcblk0p10"

--- a/recipes-kernel/linux/linux-qcom-bootimg.inc
+++ b/recipes-kernel/linux/linux-qcom-bootimg.inc
@@ -7,11 +7,10 @@ QCOM_BOOTIMG_ROOTFS_ifc6410 = "mmcblk0p12"
 QCOM_BOOTIMG_ROOTFS_sd-600eval = "mmcblk0p12"
 
 # set output file names
-DT_IMAGE_BASE_NAME = "dt-${PKGE}-${PKGV}-${PKGR}-${MACHINE}-${DATETIME}"
-DT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
-
-BOOT_IMAGE_BASE_NAME = "boot-${PKGE}-${PKGV}-${PKGR}-${MACHINE}-${DATETIME}"
-BOOT_IMAGE_BASE_NAME[vardepsexclude] = "DATETIME"
+DT_IMAGE_BASE_NAME = "dt-${KERNEL_IMAGE_BASE_NAME}"
+DT_IMAGE_SYMLINK_NAME = "dt-${KERNEL_IMAGE_SYMLINK_NAME}"
+BOOT_IMAGE_BASE_NAME = "boot-${KERNEL_IMAGE_BASE_NAME}"
+BOOT_IMAGE_SYMLINK_NAME = "boot-${KERNEL_IMAGE_SYMLINK_NAME}"
 
 do_deploy_append_aarch64() {
 
@@ -34,10 +33,8 @@ do_deploy_append_aarch64() {
               --cmdline \
               "root=/dev/${QCOM_BOOTIMG_ROOTFS} rw rootwait console=${ttydev},${baudrate}n8"
 
-    cd ${DEPLOYDIR}
-	ln -sf ${DT_IMAGE_BASE_NAME}.img dt-${MACHINE}.img
-	ln -sf ${BOOT_IMAGE_BASE_NAME}.img boot-${MACHINE}.img
-    cd -
+    ln -sf ${DT_IMAGE_BASE_NAME}.img ${DEPLOYDIR}/${DT_IMAGE_SYMLINK_NAME}.img
+    ln -sf ${BOOT_IMAGE_BASE_NAME}.img ${DEPLOYDIR}/${BOOT_IMAGE_SYMLINK_NAME}.img
 }
 
 do_deploy_append_apq8064 () {
@@ -58,7 +55,5 @@ do_deploy_append_apq8064 () {
               --cmdline \
               "root=/dev/${QCOM_BOOTIMG_ROOTFS} rw rootwait console=${ttydev},${baudrate}n8"
 
-    cd ${DEPLOYDIR}
-	ln -sf ${BOOT_IMAGE_BASE_NAME}.img boot-${MACHINE}.img
-    cd -
+    ln -sf ${BOOT_IMAGE_BASE_NAME}.img ${DEPLOYDIR}/${BOOT_IMAGE_SYMLINK_NAME}.img
 }


### PR DESCRIPTION
This replaces #21, modified based on the comments there:
- dropped the do_compile_append change
- moved the variable settings to the machine/SoC conf files
- added a variable for the page size
