### PR TITLE
dragonboard-410c: create 32-bit machine configuration

### DIFF
--- a/conf/eula/dragonboard-410c-32
+++ b/conf/eula/dragonboard-410c-32
@@ -1,0 +1,1 @@
+dragonboard-410c

--- a/conf/machine/dragonboard-410c-32.conf
+++ b/conf/machine/dragonboard-410c-32.conf
@@ -1,23 +1,21 @@
 #@TYPE: Machine
-#@NAME: dragonboard-410c
-#@DESCRIPTION: Machine configuration for the DragonBoard 410c (96boards), with Qualcomm Snapdragon 410 APQ8016.
+#@NAME: dragonboard-410c-32
+#@DESCRIPTION: 32-bit machine configuration for the DragonBoard 410c (96boards), with Qualcomm Snapdragon 410 APQ8016.
 
 require conf/machine/include/qcom-apq8016.inc
-require conf/machine/include/arm/arch-armv8.inc
+require conf/machine/include/tune-cortexa8.inc
 
 MACHINE_FEATURES = "usbhost usbgadget alsa screen wifi bluetooth ext2"
 
-KERNEL_IMAGETYPE = "Image"
-KERNEL_DEVICETREE = "qcom/apq8016-sbc.dtb"
-
 SERIAL_CONSOLE = "115200 ttyMSM0"
 
+# Building 32-bit kernel is not supported.
+PREFERRED_PROVIDER_virtual/kernel = "linux-dummy"
+RDEPENDS_kernel-base = ""
+
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
-    kernel-modules \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'wcnss-config wcnss-start', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluez5', 'bluez5-noinst-tools', '', d)} \
-    ${@'firmware-qcom-dragonboard410c' if d.getVar('ACCEPT_EULA_dragonboard-410c', True) == '1' else ''} \
+    ${@'firmware-qcom-dragonboard410c' if d.getVar('ACCEPT_EULA_dragonboard-410c-32', True) == '1' else ''} \
 "
-
-QCOM_BOOTIMG_ROOTFS ?= "mmcblk0p10"

--- a/conf/machine/include/qcom-apq8016.inc
+++ b/conf/machine/include/qcom-apq8016.inc
@@ -1,6 +1,5 @@
 SOC_FAMILY = "apq8016"
 require conf/machine/include/soc-family.inc
-require conf/machine/include/arm/arch-armv8.inc
 
 XSERVER_OPENGL ?= " \
     xf86-video-freedreno \

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard410c_1.3.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard410c_1.3.0.bb
@@ -49,7 +49,7 @@ python qcom_bin_do_unpack() {
 }
 
 python do_unpack() {
-    eula = d.getVar('ACCEPT_EULA_dragonboard-410c', True)
+    eula = d.getVar('ACCEPT_EULA_'+d.getVar('MACHINE', True), True)
     eula_file = d.getVar('QCOM_EULA_FILE', True)
     pkg = d.getVar('PN', True)
     if eula == None:


### PR DESCRIPTION
This adds a 32-bit db410c machine.
On of the usage scenarios is to build a 32-bit rootfs using this machine, and to combine it with the kernel and the modules from a 64-bit build. The 32-bit linux kernel is not needed, so we use "linux-dummy" for virtual/kernel provider, and don't include the kernel into the rootfs image.