### PR TITLE
gstreamer1.0-plugins-v4l2: Remove introspection patch forced by OE-Core

### DIFF
--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-v4l2.bb
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-v4l2.bb
@@ -14,7 +14,10 @@ SRC_URI = " \
     git://git.linaro.org/landing-teams/working/qualcomm/pkg/gst-plugins-v4l2.git;protocol=https;branch=debian;name=plugin \
     git://anongit.freedesktop.org/gstreamer/common;name=common;branch=master;destsuffix=git/common \
     file://remove-git-from-autogen.patch \
+    file://introspection-prefix-pkgconfig-paths-with-PKG_CON.patch \
 "
+
+SRC_URI_remove = "file://0001-introspection.m4-prefix-pkgconfig-paths-with-PKG_CON.patch"
 
 SRCREV_plugin = "0d051f538fe00c8a79fcf12a05a6dac3a9af7dd7"
 SRCREV_common = "12af105243823fc73581db4fd79a46f6d0268dc5"

--- a/recipes-multimedia/gstreamer/gstreamer1.0-plugins-v4l2/introspection-prefix-pkgconfig-paths-with-PKG_CON.patch
+++ b/recipes-multimedia/gstreamer/gstreamer1.0-plugins-v4l2/introspection-prefix-pkgconfig-paths-with-PKG_CON.patch
@@ -1,0 +1,39 @@
+From 90916f96262fa7b27a0a99788c69f9fd6df11000 Mon Sep 17 00:00:00 2001
+From: Alexander Kanavin <alex.kanavin@gmail.com>
+Date: Tue, 24 Nov 2015 16:46:27 +0200
+Subject: [PATCH] introspection.m4: prefix pkgconfig paths with
+ PKG_CONFIG_SYSROOT_DIR
+
+We can't use our tweaked introspection.m4 from gobject-introspection tarball
+because gstreamer also defines INTROSPECTION_INIT in its introspection.m4, which
+is later supplied to g-ir-scanner.
+
+Upstream-Status: Pending [review on oe-core list]
+Signed-off-by: Alexander Kanavin <alex.kanavin@gmail.com>
+---
+ common/m4/introspection.m4 | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
+
+Index: git/common/m4/introspection.m4
+===================================================================
+--- git.orig/common/m4/introspection.m4
++++ git/common/m4/introspection.m4
+@@ -54,14 +54,14 @@ m4_define([_GOBJECT_INTROSPECTION_CHECK_
+     INTROSPECTION_GIRDIR=
+     INTROSPECTION_TYPELIBDIR=
+     if test "x$found_introspection" = "xyes"; then
+-       INTROSPECTION_SCANNER=`$PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0`
+-       INTROSPECTION_COMPILER=`$PKG_CONFIG --variable=g_ir_compiler gobject-introspection-1.0`
+-       INTROSPECTION_GENERATE=`$PKG_CONFIG --variable=g_ir_generate gobject-introspection-1.0`
++       INTROSPECTION_SCANNER=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=g_ir_scanner gobject-introspection-1.0`
++       INTROSPECTION_COMPILER=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=g_ir_compiler gobject-introspection-1.0`
++       INTROSPECTION_GENERATE=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=g_ir_generate gobject-introspection-1.0`
+        INTROSPECTION_GIRDIR=`$PKG_CONFIG --variable=girdir gobject-introspection-1.0`
+        INTROSPECTION_TYPELIBDIR="$($PKG_CONFIG --variable=typelibdir gobject-introspection-1.0)"
+        INTROSPECTION_CFLAGS=`$PKG_CONFIG --cflags gobject-introspection-1.0`
+        INTROSPECTION_LIBS=`$PKG_CONFIG --libs gobject-introspection-1.0`
+-       INTROSPECTION_MAKEFILE=`$PKG_CONFIG --variable=datadir gobject-introspection-1.0`/gobject-introspection-1.0/Makefile.introspection
++       INTROSPECTION_MAKEFILE=$PKG_CONFIG_SYSROOT_DIR`$PKG_CONFIG --variable=datadir gobject-introspection-1.0`/gobject-introspection-1.0/Makefile.introspection
+     fi
+     AC_SUBST(INTROSPECTION_SCANNER)
+     AC_SUBST(INTROSPECTION_COMPILER)


### PR DESCRIPTION
OE-Core tries to patch every plugin thats including the .inc file
from OE-core, this however assumes that common repo is at same srcrev
for external plugins. Unfortunately this is not the case with this
v4l2 plugin. Therefore we remove the OE-Core patch and instead apply
similar patch but stored locally in qcom layer which applies cleanly
on the srcrev used by v4l2 plugin for common repo

Signed-off-by: Khem Raj raj.khem@gmail.com
