### PR TITLE
linux-linaro-qcomlt_4.4.bb: Inherit pythonnative

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_4.4.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_4.4.bb
@@ -3,6 +3,8 @@
 
 DESCRIPTION = "Linaro Qualcomm Landing team 4.4 Kernel"
 
+inherit pythonnative
+
 require recipes-kernel/linux/linux-linaro-qcom.inc
 require recipes-kernel/linux/linux-dtb.inc
 require recipes-kernel/linux/linux-qcom-bootimg.inc


### PR DESCRIPTION
This kernel uses dtbTool ( a python script) during build
this script ends up poking at host python and if you use
something like archlinux then your python version will be
different then python-native and it will result in compile
errors e.g.

| Traceback (most recent call last):
|   File "/mnt/b/build/tmp-glibc/sysroots/x86_64-linux/usr/bin/dtbTool", line 34, in <module>
|     from struct import pack, unpack
|   File "/usr/lib/python2.7/struct.py", line 1, in <module>
|     from _struct import *
| ImportError: /usr/lib/python2.7/lib-dynload/_struct.so: undefined symbol: PyUnicodeUCS4_AsEncodedString

therefore inherit pythonnative to limit it to use the python
from native sysroot for consistency across different build hosts

Signed-off-by: Khem Raj <raj.khem@gmail.com>