### PR TITLE
410c: disable schedutils

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -19,3 +19,5 @@ BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bbappend' % layer \
 # Add layer-specific bb files too
 BBFILES += "${@' '.join('${LAYERDIR}/%s/recipes*/*/*.bb' % layer \
               for layer in BBFILE_COLLECTIONS.split())}"
+
+EXTRA_OECONF_append_util-linux = " --disable-schedutils" 


### PR DESCRIPTION
Without it `bitbake core-image-minimal` errors:

```error: ‘__NR_sched_setattr’ undeclared (first use in this function)```