### PR TITLE
mesa: add patch to fix glmark2 hangcheck

### DIFF
--- a/recipes-graphics/mesa/mesa/dragon410c-freedreno-hangcheck-workaround.patch
+++ b/recipes-graphics/mesa/mesa/dragon410c-freedreno-hangcheck-workaround.patch
@@ -1,0 +1,16 @@
+diff --git a/src/gallium/drivers/freedreno/a3xx/fd3_gmem.c b/src/gallium/drivers/freedreno/a3xx/fd3_gmem.c
+index 493fdd29e5..5e09dabff1 100644
+--- a/src/gallium/drivers/freedreno/a3xx/fd3_gmem.c
++++ b/src/gallium/drivers/freedreno/a3xx/fd3_gmem.c
+@@ -131,6 +131,11 @@ static bool
+ use_hw_binning(struct fd_batch *batch)
+ {
+ 	struct fd_gmem_stateobj *gmem = &batch->ctx->gmem;
++	struct pipe_framebuffer_state *pfb = &batch->framebuffer;
++
++	/* only on a306?? maybe something w/ gmem layout or too many bins? */
++	if ((pfb->width > 2048) && (pfb->height > 2048))
++		return false;
+ 
+ 	/* workaround: combining scissor optimization and hw binning
+ 	 * seems problematic.  Seems like we end up with a mismatch

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,3 +1,7 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+
+SRC_URI_append_apq8016 = " file://dragon410c-freedreno-hangcheck-workaround.patch"
+
 # Enable freedreno driver
 GALLIUMDRIVERS_append_apq8064 = ",freedreno"
 GALLIUMDRIVERS_append_apq8016 = ",freedreno"


### PR DESCRIPTION
While executing the [shadow] and [refract] tests of glmark2 in fullscreen,
a hangcheck occurs. This patch comes from Rob Clark and is a temporary gpu
specific fix.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>