### PR TITLE
qrtr: upgrade recipe version

### DIFF
--- a/recipes-support/qrtr/qrtr_git.bb
+++ b/recipes-support/qrtr/qrtr_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=15329706fbfcb5fc5edcc1bc7c139da5"
 
 inherit systemd
 
-SRCREV = "56074bd5fe8f487b3a681b73e669cdbfe3b7b555"
+SRCREV = "dee8a384dc6ba02d41caa1f61d0b267c4ba74ff0"
 SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https"
 SRC_URI += "file://qrtr.service"
 
@@ -15,8 +15,10 @@ PV = "0.0+${SRCPV}"
 
 S = "${WORKDIR}/git"
 
+EXTRA_OEMAKE = "prefix=${prefix} bindir=${bindir} libdir=${libdir} includedir=${includedir} LDFLAGS='${LDFLAGS}'"
+
 do_install () {
-    oe_runmake install DESTDIR=${D} prefix=${prefix}
+    oe_runmake install DESTDIR=${D}
 
     sed -i -e s:/usr/bin:${bindir}:g ${WORKDIR}/qrtr.service
     install -d ${D}${systemd_unitdir}/system/


### PR DESCRIPTION
* upstream has fixed multilib/multiarch, so update recipe accordingly
* also fixes "QA Issue: No GNU_HASH in the elf binary"

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>