### PR TITLE
mesa: Enable texture-float extension

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -8,12 +8,18 @@ PACKAGECONFIG_append_apq8064 = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'xa', '', d)} \
 "
 
+EXTRA_OECONF_append_apq8064 = " --enable-texture-float"
+
 PACKAGECONFIG_append_apq8016 = " \
     gallium \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'xa', '', d)} \
 "
 
+EXTRA_OECONF_append_apq8016 = " --enable-texture-float"
+
 PACKAGECONFIG_append_apq8096 = " \
     gallium \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'xa', '', d)} \
 "
+
+EXTRA_OECONF_append_apq8096 = " --enable-texture-float"


### PR DESCRIPTION
Texture float extension is requested to be OpenGL ES 3.0 compliant.
Since this extension is not enabled by default, add it in the bbapend.

Signed-off-by: Loic Poulain <loic.poulain@linaro.org>