### PR TITLE
linux-linaro-qcomlt: stop using linux-dtb.inc

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt-db820c_4.11.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-db820c_4.11.bb
@@ -4,7 +4,6 @@
 DESCRIPTION = "Linaro Qualcomm Landing team 4.11 Kernel"
 
 require recipes-kernel/linux/linux-linaro-qcom.inc
-require recipes-kernel/linux/linux-dtb.inc
 require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 LOCALVERSION ?= "-linaro-lt-qcom"

--- a/recipes-kernel/linux/linux-linaro-qcomlt_4.9.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_4.9.bb
@@ -6,7 +6,6 @@ DESCRIPTION = "Linaro Qualcomm Landing team 4.9 Kernel"
 inherit pythonnative
 
 require recipes-kernel/linux/linux-linaro-qcom.inc
-require recipes-kernel/linux/linux-dtb.inc
 require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 LOCALVERSION ?= "-linaro-lt-qcom"


### PR DESCRIPTION
Device tree support is now handled by the kernel class.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>