### PR TITLE
dragonboard-410c.conf: use wic.gz by default

### DIFF
--- a/conf/machine/dragonboard-410c.conf
+++ b/conf/machine/dragonboard-410c.conf
@@ -26,6 +26,6 @@ QCOM_BOOTIMG_ROOTFS ?= "mmcblk0p10"
 SD_QCOM_BOOTIMG_ROOTFS ?= "mmcblk1p7"
 
 # Assemble SD card
-IMAGE_FSTYPES_append = " wic"
+IMAGE_FSTYPES_append = " wic.gz"
 WKS_FILE = "dragonboard410c-sd.wks"
 WKS_FILE_DEPENDS = "firmware-qcom-dragonboard410c-bootloader-sdcard"


### PR DESCRIPTION
Prefer the compressed version of the sdcard image by default as it is
substantially smaller.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>