### PR TITLE
dragonboard-410c.conf: add wic.bmap image type

### DIFF
--- a/conf/machine/dragonboard-410c.conf
+++ b/conf/machine/dragonboard-410c.conf
@@ -26,6 +26,6 @@ QCOM_BOOTIMG_ROOTFS ?= "mmcblk0p10"
 SD_QCOM_BOOTIMG_ROOTFS ?= "mmcblk1p7"
 
 # Assemble SD card
-IMAGE_FSTYPES_append = " wic.gz"
+IMAGE_FSTYPES_append = " wic.gz wic.bmap"
 WKS_FILE = "dragonboard410c-sd.wks"
 WKS_FILE_DEPENDS = "firmware-qcom-dragonboard410c-bootloader-sdcard"


### PR DESCRIPTION
It would allow us to avoid uncompressing wic image every time
we update SD card with new image using bmap-tools.

Signed-off-by: Héctor Orón Martínez <hector.oron@collabora.co.uk>