### PR TITLE
firmware-qcom: use nonarch_base_libdir instead of /lib

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-dragonboard410c_1032.1.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard410c_1032.1.bb
@@ -19,23 +19,23 @@ do_compile() {
 }
 
 do_install() {
-    install -d  ${D}/lib/firmware/
-    cp -r ./proprietary-linux/* ${D}/lib/firmware/
+    install -d  ${D}${nonarch_base_libdir}/firmware/
+    cp -r ./proprietary-linux/* ${D}${nonarch_base_libdir}/firmware/
 
     MTOOLS_SKIP_CHECK=1 mcopy -i ./bootloaders-linux/NON-HLOS.bin \
-    ::image/modem.* ::image/mba.mbn ::image/wcnss.* ${D}/lib/firmware/
+    ::image/modem.* ::image/mba.mbn ::image/wcnss.* ${D}${nonarch_base_libdir}/firmware/
 
     # Venus firmware have been merged in linux-firmware in a different location than
     # what we've been using for now. Let's add symlinks for now, until we switch to linux-firmware
-    install -d ${D}/lib/firmware/qcom/venus-1.8/
-    for f in ${D}/lib/firmware/venus.*; do
+    install -d ${D}${nonarch_base_libdir}/firmware/qcom/venus-1.8/
+    for f in ${D}${nonarch_base_libdir}/firmware/venus.*; do
         f=$(basename $f)
-        ln -s /lib/firmware/$f ${D}/lib/firmware/qcom/venus-1.8/$f
+        ln -s ${nonarch_base_libdir}/firmware/$f ${D}${nonarch_base_libdir}/firmware/qcom/venus-1.8/$f
     done
 
     install -d ${D}${sysconfdir}/
     install -m 0644 LICENSE ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE
 }
 
-FILES_${PN} += "/lib/firmware/*"
+FILES_${PN} += "${nonarch_base_libdir}/firmware/*"
 INSANE_SKIP_${PN} += "arch"

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard820c_01700.1.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard820c_01700.1.bb
@@ -17,16 +17,16 @@ do_compile() {
 }
 
 do_install() {
-    install -d ${D}/lib/firmware/
-    install -d ${D}/lib/firmware/qcom/venus-4.2/
+    install -d ${D}${nonarch_base_libdir}/firmware/
+    install -d ${D}${nonarch_base_libdir}/firmware/qcom/venus-4.2/
     
-    install -m 0444 ./proprietary-linux/a530*.* ${D}/lib/firmware/
-    install -m 0444 ./proprietary-linux/venus.* ${D}/lib/firmware/qcom/venus-4.2/
-    install -m 0444 ./proprietary-linux/adsp.* ${D}/lib/firmware/
+    install -m 0444 ./proprietary-linux/a530*.* ${D}${nonarch_base_libdir}/firmware/
+    install -m 0444 ./proprietary-linux/venus.* ${D}${nonarch_base_libdir}/firmware/qcom/venus-4.2/
+    install -m 0444 ./proprietary-linux/adsp.* ${D}${nonarch_base_libdir}/firmware/
 
     install -d ${D}${sysconfdir}/
     install -m 0644 LICENSE ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE
 }
 
-FILES_${PN} += "/lib/firmware/*"
+FILES_${PN} += "${nonarch_base_libdir}/firmware/*"
 INSANE_SKIP_${PN} += "arch"


### PR DESCRIPTION
Hardcoded /lib is not compatible with usrmerge.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>