### PR TITLE
conf/machine: dragonboard-820c.conf change to use rootfs (sda7)

### DIFF
--- a/conf/machine/dragonboard-820c.conf
+++ b/conf/machine/dragonboard-820c.conf
@@ -18,7 +18,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k', '', d)} \
 "
 
-QCOM_BOOTIMG_ROOTFS ?= "sde18"
+QCOM_BOOTIMG_ROOTFS ?= "sda7"
 
 # UFS partitions setup with 4096 logical sector size
 EXTRA_IMAGECMD_ext4 += " -b 4096 "


### PR DESCRIPTION
The last bootloader dosen't include the system partition so use
rootfs instead [1], the same change was applied in Debian build [2].

[1]
http://snapshots.linaro.org/96boards/dragonboard820c/linaro/rescue/27/
[2]
https://git.linaro.org/ci/job/configs.git/commit/?id=b4684a2f44

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>