### PR TITLE
Define default u-boot machine for db410c and db820c

### DIFF
--- a/conf/machine/dragonboard-410c.conf
+++ b/conf/machine/dragonboard-410c.conf
@@ -25,6 +25,8 @@ QCOM_BOOTIMG_ROOTFS ?= "mmcblk0p10"
 # Define rootfs partiton (kernel argument)
 SD_QCOM_BOOTIMG_ROOTFS ?= "mmcblk1p7"
 
+UBOOT_MACHINE ?= "dragonboard410c_defconfig"
+
 # Assemble SD card
 IMAGE_FSTYPES_append = " wic.gz wic.bmap"
 WKS_FILE = "dragonboard410c-sd.wks"

--- a/conf/machine/dragonboard-820c.conf
+++ b/conf/machine/dragonboard-820c.conf
@@ -20,5 +20,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 
 QCOM_BOOTIMG_ROOTFS ?= "sda7"
 
+UBOOT_MACHINE ?= "dragonboard820c_defconfig"
+
 # UFS partitions setup with 4096 logical sector size
 EXTRA_IMAGECMD_ext4 += " -b 4096 "


### PR DESCRIPTION
Both boards are supported by u-boot upstream (chainloaded from lk).