### PR TITLE
recipes-test: Add initramfs-bootrr-image

### DIFF
--- a/recipes-test/bootrr/bootrr.bb
+++ b/recipes-test/bootrr/bootrr.bb
@@ -1,0 +1,16 @@
+SUMMARY = "Boot regression testing (bootrr) for Qualcomm boards"
+SECTION = "test"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRCREV = "365a5ee5fec5f6c28bf05764d0b9e16fe2b8e560"
+SRC_URI = "git://git@github.com/andersson/${BPN}.git;branch=master;protocol=https"
+
+PV = "0.0+${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+do_install() {
+	oe_runmake install DESTDIR=${D} prefix=${prefix}
+}

--- a/recipes-test/images/initramfs-bootrr-image.bb
+++ b/recipes-test/images/initramfs-bootrr-image.bb
@@ -1,0 +1,19 @@
+DESCRIPTION = "Small ramdisk image for running bootrr"
+
+PACKAGE_INSTALL = "bootrr-init busybox base-passwd ${ROOTFS_BOOTSTRAP_INSTALL} qrtr-apps udev bootrr rmtfs gptfdisk lava-test-shell"
+
+# Do not pollute the initrd image with rootfs features
+IMAGE_FEATURES = ""
+
+export IMAGE_BASENAME = "initramfs-bootrr-image"
+IMAGE_LINGUAS = ""
+
+LICENSE = "MIT"
+
+IMAGE_FSTYPES = "${INITRAMFS_FSTYPES}"
+inherit core-image
+
+IMAGE_ROOTFS_SIZE = "8192"
+IMAGE_ROOTFS_EXTRA_SPACE = "0"
+
+BAD_RECOMMENDATIONS += "busybox-syslog"

--- a/recipes-test/initrdscripts/bootrr-init.bb
+++ b/recipes-test/initrdscripts/bootrr-init.bb
@@ -1,0 +1,14 @@
+SUMMARY = "Basic init script to launch test scripts"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+SRC_URI = "file://init-debug.sh"
+
+S = "${WORKDIR}"
+
+do_install() {
+        install -m 0755 ${WORKDIR}/init-debug.sh ${D}/init
+}
+
+inherit allarch
+
+FILES_${PN} += " /init "

--- a/recipes-test/initrdscripts/files/init-debug.sh
+++ b/recipes-test/initrdscripts/files/init-debug.sh
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+HOME=/root
+PATH=/sbin:/bin:/usr/sbin:/usr/bin
+PS1="linaro-test [rc=$(echo \$?)]# "
+export HOME PS1 PATH
+
+do_mount_fs() {
+	grep -q "$1" /proc/filesystems || return
+	test -d "$2" || mkdir -p "$2"
+	mount -t "$1" "$1" "$2"
+}
+
+do_mknod() {
+	test -e "$1" || mknod "$1" "$2" "$3" "$4"
+}
+
+mkdir -p /proc
+mount -t proc proc /proc
+
+do_mount_fs sysfs /sys
+do_mount_fs debugfs /sys/kernel/debug
+do_mount_fs devtmpfs /dev
+do_mount_fs devpts /dev/pts
+do_mount_fs tmpfs /dev/shm
+
+mkdir -p /run
+mkdir -p /var/run
+
+/sbin/udevd --daemon
+
+do_mknod /dev/console c 5 1
+do_mknod /dev/null c 1 3
+do_mknod /dev/zero c 1 5
+
+exec sh </dev/console >/dev/console 2>/dev/console

--- a/recipes-test/lava-test-shell/lava-test-shell.bb
+++ b/recipes-test/lava-test-shell/lava-test-shell.bb
@@ -1,0 +1,20 @@
+SUMMARY = "Lava test shell helpers"
+SECTION = "test"
+
+LICENSE = "GPLv2"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRCREV = "dcf554ef9b89c74d028734c74edea1ef5e777d33"
+SRC_URI = "git://git.linaro.org/lava/lava-dispatcher.git;branch=release;protocol=https"
+
+PV = "2018.2+${SRCPV}"
+
+S = "${WORKDIR}/git"
+
+do_install() {
+        mkdir -p ${D}${bindir}
+	for file in $(ls lava_dispatcher/lava_test_shell/lava-*)
+	do
+		install -m 0755 $file ${D}${bindir}/$(basename $file)
+	done
+}


### PR DESCRIPTION
A minimal ramdisk suitable for testing, imported from,

https://github.com/andersson/meta-stuff

Recipes added,

- bootrr: Boot regression testing
- lava-test-shell: Lava test shell helpers to execute bootrr
  outside LAVA environment

LAVA test definition run example,

https://validation.linaro.org/scheduler/job/1692990

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>