### PR TITLE
machine: do not use _append for IMAGE_FSTYPES

### DIFF
--- a/conf/machine/dragonboard-410c.conf
+++ b/conf/machine/dragonboard-410c.conf
@@ -28,6 +28,6 @@ SD_QCOM_BOOTIMG_ROOTFS ?= "mmcblk1p7"
 UBOOT_MACHINE ?= "dragonboard410c_defconfig"
 
 # Assemble SD card
-IMAGE_FSTYPES_append = " wic.gz wic.bmap"
+IMAGE_FSTYPES += "wic.gz wic.bmap"
 WKS_FILE = "dragonboard410c-sd.wks"
 WKS_FILE_DEPENDS = "firmware-qcom-dragonboard410c-bootloader-sdcard"

--- a/conf/machine/include/qcom-apq8016.inc
+++ b/conf/machine/include/qcom-apq8016.inc
@@ -23,7 +23,7 @@ PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-linaro-qcomlt"
 
 # Fastboot expects an ext4 image, which needs to be 4096 aligned
-IMAGE_FSTYPES_append = " ext4.gz"
+IMAGE_FSTYPES ?= "ext4.gz"
 IMAGE_ROOTFS_ALIGNMENT = "4096"
 
 QCOM_BOOTIMG_KERNEL_BASE ?= "0x80000000"

--- a/conf/machine/include/qcom-apq8064.inc
+++ b/conf/machine/include/qcom-apq8064.inc
@@ -22,7 +22,7 @@ PREFERRED_PROVIDER_virtual/xserver = "xserver-xorg"
 PREFERRED_PROVIDER_virtual/kernel = "linux-linaro-qcomlt"
 
 # Fastboot expects an ext4 image, which needs to be 4096 aligned
-IMAGE_FSTYPES_append = " ext4.gz"
+IMAGE_FSTYPES ?= "ext4.gz"
 IMAGE_ROOTFS_ALIGNMENT = "4096"
 
 QCOM_BOOTIMG_KERNEL_BASE ?= "0x80200000"

--- a/conf/machine/include/qcom-apq8096.inc
+++ b/conf/machine/include/qcom-apq8096.inc
@@ -24,7 +24,7 @@ PREFERRED_PROVIDER_virtual/xserver ?= "xserver-xorg"
 PREFERRED_PROVIDER_virtual/kernel ?= "linux-linaro-qcomlt"
 
 # Fastboot expects an ext4 image, which needs to be 4096 aligned
-IMAGE_FSTYPES_append = " ext4.gz"
+IMAGE_FSTYPES ?= "ext4.gz"
 IMAGE_ROOTFS_ALIGNMENT = "4096"
 
 QCOM_BOOTIMG_KERNEL_BASE ?= "0x80000000"


### PR DESCRIPTION
As discussed on https://github.com/ndechesne/meta-qcom/issues/61, using _append
will modify IMAGE_FSTYPES unconditionnally and won't give DISTRO a chance to
override.

Let's set sane, default settings using ?= (or +=). If a DISTRO wants to change
them, we suppose they know what they do, and overwrite correctly.

Reported-by: Jan-Simon Möller <jsmoeller@linuxfoundation.org>
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>