### PR TITLE
layer.conf: add LAYERSERIES_COMPAT markup

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,6 +8,7 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "qcom"
 BBFILE_PATTERN_qcom := "^${LAYERDIR}/"
 BBFILE_PRIORITY_qcom = "5"
+LAYERSERIES_COMPAT_qcom = "sumo"
 
 # Let us add layer-specific bbappends which are only applied when that
 # layer is included in our configuration


### PR DESCRIPTION
Allows the user to easily identify if the layer is compatible with
oe-core.

Signed-off-by: Ricardo Salveti <ricardo@opensourcefoundries.com>