### PR TITLE
Enable lab-bjorn to run straight off qcom/rocko

### DIFF
--- a/recipes-test/bootrr/bootrr.bb
+++ b/recipes-test/bootrr/bootrr.bb
@@ -4,7 +4,7 @@ SECTION = "test"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-SRCREV = "365a5ee5fec5f6c28bf05764d0b9e16fe2b8e560"
+SRCREV = "ccc99d87f7c3807289fd60d56baa4af5747cebc3"
 SRC_URI = "git://git@github.com/andersson/${BPN}.git;branch=master;protocol=https"
 
 PV = "0.0+${SRCPV}"

--- a/recipes-test/initrdscripts/files/init-debug.sh
+++ b/recipes-test/initrdscripts/files/init-debug.sh
@@ -34,4 +34,17 @@ do_mknod /dev/console c 5 1
 do_mknod /dev/null c 1 3
 do_mknod /dev/zero c 1 5
 
+echo -n 'BOOT TIME: '
+cat /proc/uptime
+
+if $(grep -q bootrr-auto /proc/cmdline); then
+	for TEST in $(tr "\0" "\n" < /proc/device-tree/compatible); do
+		if [ -x "/usr/bin/${TEST}" ]; then
+			/usr/bin/${TEST}
+		fi
+	done
+
+	echo ~~~~~~~~~~~~~~~~~~~~~
+fi
+
 exec sh </dev/console >/dev/console 2>/dev/console

--- a/recipes-test/initrdscripts/files/init-debug.sh
+++ b/recipes-test/initrdscripts/files/init-debug.sh
@@ -28,6 +28,7 @@ mkdir -p /run
 mkdir -p /var/run
 
 /sbin/udevd --daemon
+/bin/udevadm trigger
 
 do_mknod /dev/console c 5 1
 do_mknod /dev/null c 1 3


### PR DESCRIPTION
This bumps the bootrr recipe to use the latest commit from the bootrr project, fixes kernel module auto loading and makes it possible to automatically run the bootrr board scripts in a LAVAless environment. 