### PR TITLE
bootrr: Bump revision

### DIFF
--- a/recipes-test/bootrr/bootrr.bb
+++ b/recipes-test/bootrr/bootrr.bb
@@ -4,7 +4,7 @@ SECTION = "test"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-SRCREV = "25e06598f1b322d8b11e55ca924b496ed18866bf"
+SRCREV = "ca9605bd7211f20feaa18a7c454906b2fc4a602e"
 SRC_URI = "git://git@github.com/andersson/${BPN}.git;branch=master;protocol=https"
 
 PV = "0.0+${SRCPV}"


### PR DESCRIPTION
Bjorn Andersson (2):
      helpers: Allow timeout in assert_driver as well
      boards: db820c: Test for atl1c and ath10k_pci

Signed-off-by: Bjorn Andersson <bjorn.andersson@linaro.org>