### PR TITLE
diag: Bump revision to fix SDM845 support

### DIFF
--- a/recipes-test/diag/diag_git.bb
+++ b/recipes-test/diag/diag_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=f6832ae4af693c6f31ffd931e25ef580"
 SRC_URI = "git://github.com/andersson/diag.git;protocol=https"
 
 PV = "0.0+git${SRCPV}"
-SRCREV = "9de0697ec5447dddbc0caf5744042e41a3a7c2ea"
+SRCREV = "5ef6b6b0c50047be3dd456d91d9a6dd730ba99e2"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Bjorn Andersson (1):
      qrtr: Register the DCI and not DCI_CMD instance

Khem Raj (1):
    Fix build with musl

Signed-off-by: Bjorn Andersson <bjorn.andersson@linaro.org>