### PR TITLE
Update skales SRC_URI to fetch via HTTP

### DIFF
--- a/recipes-devtools/skales/skales_git.bb
+++ b/recipes-devtools/skales/skales_git.bb
@@ -11,7 +11,7 @@ DEPENDS = "python dtc"
 SRCREV = "6eac9e943de53c4aaaede3697e9226a47686fe25"
 PV = "1.5.0+git${SRCPV}"
 
-SRC_URI = "git://codeaurora.org/quic/kernel/skales"
+SRC_URI = "git://source.codeaurora.org/quic/cc-qrdk/oss/tools/skales;protocol=http;branch=skales/master"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
As written, the SRC_URI for the skales recipe causes the fetch step to fail for developers operating behind corporate HTTP proxies.  This commit should make the recipe Just Work t.m. for a larger number of users.