### PR TITLE
conf/machine/include/qcom-apq8016.inc: Load qcom_q6v5_pil afer rmtfs 

### DIFF
--- a/conf/machine/include/qcom-apq8016.inc
+++ b/conf/machine/include/qcom-apq8016.inc
@@ -33,3 +33,6 @@ IMAGE_ROOTFS_ALIGNMENT = "4096"
 
 QCOM_BOOTIMG_KERNEL_BASE ?= "0x80000000"
 QCOM_BOOTIMG_PAGE_SIZE ?= "2048"
+
+KERNEL_MODULE_PROBECONF += "qcom_q6v5_pil"
+module_conf_qcom_q6v5_pil = "blacklist qcom_q6v5_pil"

--- a/recipes-support/rmtfs/files/rmtfs.service
+++ b/recipes-support/rmtfs/files/rmtfs.service
@@ -9,6 +9,7 @@ ExecStartPre=/bin/sh -c "[ ! -f /boot/modem_fs2 ] &&  dd if=/dev/zero of=/boot/m
 ExecStartPre=/bin/sh -c "[ ! -f /boot/modem_fsc ] &&  dd if=/dev/zero of=/boot/modem_fsc bs=1M count=2 || :"
 ExecStartPre=/bin/sh -c "[ ! -f /boot/modem_fsg ] &&  dd if=/dev/zero of=/boot/modem_fsg bs=1M count=2 || :"
 ExecStart=/usr/bin/rmtfs -v
+ExecStartPost=/bin/sh -c "[ -d /sys/bus/platform/devices/*.hexagon ] && modprobe qcom_q6v5_pil"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
To workaround problems when the DSP isn't ready load
qcom_q6v5_pil after rmtfs, blacklist the module to avoid
autoload on boot.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>