### PR TITLE
recipes-kernel/linux: Update to the latest release 4.14.90

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_4.14.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_4.14.bb
@@ -10,7 +10,7 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "release/qcomlt-4.14"
-SRCREV ?= "0848e5631cd2f8b3826e09e83287b98193364883"
+SRCREV ?= "0407ad53548e3fff6fd2dbb45d85cfbdb44b0e48"
 
 COMPATIBLE_MACHINE = "(apq8064|apq8016|apq8096)"
 


### PR DESCRIPTION
Changeset,

0407ad53548e Merge tag 'v4.14.90' into release/qcomlt-4.14
037d52f70643 Merge remote-tracking branch 'loic/qcomlt-4.14-usb' into release/qcomlt-4.14
6d39111aacb6 Merge remote-tracking branch 'loic/qcomlt-4.14-watchdog' into release/qcomlt-4.14
4bcf1b48c25a arm: dts: qcom: db410c: Enable USB OTG support
fb3832787df1 phy: qcom-usb-hs: Fix unbalanced notifier registration
ed0628fbc330 usb: chipidea: Fix otg event handler
1c164955ea22 usb: chipidea: Prevent unbalanced IRQ disable
d819d86175e9 doc: usb: ci-hdrc-usb2: Add pinctrl properties definition
9fda0b18729d usb: chipidea: Add dynamic pinctrl selection
0540174cb689 arm64: defconfig: Enable PM8916 watchdog driver
02aaff80f217 arm64: dts: qcom: pm8916: Add PON watchdog node
1cdd7c9f2f11 dt-bindings: watchdog: Add Qualcomm PM8916 watchdog
7a80ff2a7329 watchdog: Add pm8916 watchdog driver
cbefafa9cc97 Merge tag 'v4.14.89' into release/qcomlt-4.14
23b2661932d8 Merge remote-tracking branch 'loic/qcomlt-4.14-sdcard' into release/qcomlt-4.14
002be530b72d arm64: dts: apq8016-sbc: Increase load on l11 for SDCARD
e6415afc1aef arm64: dts: apq8096-db820c: Increase load on l21 for SDCARD
7167b90eaedd mmc: sdhci-msm: Disable CDR function on TX
4700fc2598f6 Merge tag 'v4.14.87' into release/qcomlt-4.14
6a4b42375b0c Merge tag 'v4.14.85' into release/qcomlt-4.14
8f0b3024d52b mmc: sdhci-msm: Disable CDR function on TX
ed3f03247f21 arm64: dts: qcom: msm8996: Disable USB2 PHY suspend by core
40193cb7b204 Merge tag 'v4.14.82' into release/qcomlt-4.14

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>