### PR TITLE
initrafs-bootrr: use initramfs-framework

### DIFF
--- a/recipes-test/images/initramfs-bootrr-image.bb
+++ b/recipes-test/images/initramfs-bootrr-image.bb
@@ -1,6 +1,14 @@
 DESCRIPTION = "Small ramdisk image for running bootrr"
 
+INITRAMFS_SCRIPTS ?= "\
+    initramfs-framework-base \
+    initramfs-module-udev \
+    initramfs-module-debug \
+    initramfs-module-exec \
+                     "
+
 PACKAGE_INSTALL = " \
+    ${INITRAMFS_SCRIPTS} \
     ${ROOTFS_BOOTSTRAP_INSTALL} \
     busybox \
     base-passwd \


### PR DESCRIPTION
OE-core includes its own mechanism to generate initramfs images,
through initramfs-framework which provides all basics scripts/tools
needed (mount /dev, /proc, /sys, ...), using the 'exec' module from
initramfs-framework, we can run programs on boot by simply dropping
them into /exec.d/, this can be used for validation and CI.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>