### PR TITLE
recipes-kernel/linux: Update linux-linaro-qcomlt_4.14 to fix venus

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_4.14.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_4.14.bb
@@ -10,7 +10,7 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "release/qcomlt-4.14"
-SRCREV ?= "0407ad53548e3fff6fd2dbb45d85cfbdb44b0e48"
+SRCREV ?= "5354ea814aebe6f066d55a6a0840831fa638d20a"
 
 COMPATIBLE_MACHINE = "(apq8064|apq8016|apq8096)"
 


### PR DESCRIPTION
Changeset,

5354ea814a venus: enc: fix enum_frameintervals

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>