### PR TITLE
Update default tune configuration based on latest OE-Core

### DIFF
--- a/conf/machine/dragonboard-410c.conf
+++ b/conf/machine/dragonboard-410c.conf
@@ -3,7 +3,7 @@
 #@DESCRIPTION: Machine configuration for the DragonBoard 410c (96boards), with Qualcomm Snapdragon 410 APQ8016.
 
 require conf/machine/include/qcom-apq8016.inc
-require conf/machine/include/arm/arch-armv8.inc
+require conf/machine/include/tune-cortexa53.inc
 
 MACHINE_FEATURES = "usbhost usbgadget alsa screen wifi bluetooth ext2"
 

--- a/conf/machine/include/qcom-apq8096.inc
+++ b/conf/machine/include/qcom-apq8096.inc
@@ -1,6 +1,6 @@
 SOC_FAMILY = "apq8096"
 require conf/machine/include/soc-family.inc
-require conf/machine/include/arm/arch-armv8.inc
+require conf/machine/include/arm/arch-armv8a.inc
 
 XSERVER_OPENGL ?= " \
     xf86-video-modesetting \


### PR DESCRIPTION
Latest OE-Core removed the arch-armv8 tune file and added a new set of tune files cortex A cores.

@kraj another heads up.