### PR TITLE
recipes-kernel: Add linux-firmware_git.bbappend for dragonboard820c

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_git.bbappend
@@ -1,0 +1,7 @@
+# XXX: Checkout previous ath10k stable firmware for dragonboard820c,
+# RM.4.4.1.c2-00057-QCARMSWP-1 causes a HW reboot use RM.4.4.1-00079-QCARMSWPZ-1 
+do_install_dragonboard-820c_prepend() {
+    linux_firmware_ath10k_stable="1d1dd4be21cde408b0fb12774d477293bc8d4cc2"
+    cd "${S}"
+    git checkout "${linux_firmware_ath10k_stable}" -- ath10k/QCA6174
+}


### PR DESCRIPTION
Downgrade to stable version of ath10k firmware for dragonboard820c,
RM.4.4.1.c2-00057-QCARMSWP-1 version is causing a HW reboot [1]
use RM.4.4.1-00079-QCARMSWPZ-1 instead.

A new version that fixed the problem is available [2] but not landed
linux-firmware yet.

[1] https://validation.linaro.org/scheduler/job/1906358#L2444
[2] https://github.com/kvalo/ath10k-firmware/blob/master/QCA6174/hw3.0/4.4.1/firmware-6.bin_WLAN.RM.4.4.1-00132-QCARMSWP-1

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>