### PR TITLE
Valid initrd fix boot issue on SD820

### DIFF
--- a/recipes-kernel/linux/linux-qcom-bootimg.inc
+++ b/recipes-kernel/linux/linux-qcom-bootimg.inc
@@ -38,9 +38,8 @@ do_deploy_append() {
     baudrate=`echo $tmp | sed 's/\;.*//'`
     ttydev=`echo $tmp | sed -e 's/^[0-9]*\;//' -e 's/\s.*//' -e 's/\;.*//'`
 
-    # mkbootimg requires an initrd file, make fake one that will be ignored
-    # during boot
-    echo "This is not an initrd" > ${B}/initrd.img
+    # dummy initrd file required by mkbootimg
+    echo "." | cpio --create --format='newc' | gzip - > ${B}/initrd.img
 
     # don't build bootimg if rootfs partition is not defined
     if [ "${QCOM_BOOTIMG_ROOTFS}" == "undefined"]; then


### PR DESCRIPTION
This change fix a boot issue:

    [    0.849690] Initramfs unpacking failed: junk in compressed archive
    [    0.913369] ufs_qcom_phy_qmp_14nm 627000.phy: invalid resource
    [    0.916028] qcom-pcie 600000.pcie: Failed to get supply 'vddpe-3v3': -517
    [    1.924849] qcom-pcie 608000.pcie: Phy link never came up
    [    1.926456] qcom-pcie 608000.pcie: cannot initialize host
    [    2.173672] ufshcd-qcom 624000.ufshc: ufshcd_print_pwr_info:[RX, TX]: gear=[1, 1], lane[1, 1], pwr[SLOWAUTO_MODE, SLOWAUTO_MODE], rate = 0
    [    2.235323] dwc3 7600000.dwc3: Failed to get clk 'ref': -2
    [    2.237718] dwc3 6a00000.dwc3: Failed to get clk 'ref': -2
    [    2.242360] i2c_qup 75b5000.i2c:
    [    2.242360]  tx channel not available
    [    2.246507] i2c_qup 75b6000.i2c:
    [    2.246507]  tx channel not available
    [    2.253187] i2c_qup 7577000.i2c:
    [    2.253187]  tx channel not available
    [    2.416921] ufshcd-qcom 624000.ufshc: ufshcd_print_pwr_info:[RX, TX]: gear=[3, 3], lane[1, 1], pwr[FAST MODE, FAST MODE], rate = 2
    [    2.530560] dwc3 7600000.dwc3: Failed to get clk 'ref': -2
    [    2.538541] dwc3 6a00000.dwc3: Failed to get clk 'ref': -2
    [    2.574903] Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(259,2)
    [    2.574928] CPU: 0 PID: 1 Comm: swapper/0 Not tainted 5.0.0-rc1 #1
    [    2.582393] Hardware name: Qualcomm Technologies, Inc. DB820c (DT)
    [    2.588382] Call trace:
    [    2.594552]  dump_backtrace+0x0/0x178
    [    2.596888]  show_stack+0x14/0x20
    [    2.600710]  dump_stack+0x84/0xa4
    [    2.604007]  panic+0x13c/0x2ec
    [    2.607306]  mount_block_root+0x1a0/0x284
    [    2.610254]  mount_root+0x140/0x174
    [    2.614335]  prepare_namespace+0x138/0x180
    [    2.617634]  kernel_init_freeable+0x220/0x240
    [    2.621804]  kernel_init+0x10/0x108
    [    2.626229]  ret_from_fork+0x10/0x18
    [    2.629539] SMP: stopping secondary CPUs
    [    2.633465] Kernel Offset: disabled
    [    2.637253] CPU features: 0x002,20802008
    [    2.640463] Memory Limit: none
    [    2.644645] ---[ end Kernel panic - not syncing: VFS: Unable to mount root fs on unknown-block(259,2) ]---

This problem was introduced by this change on Linux:

    commit ff1522bb7d98450c72aea729f0b4147bc9986aed
    Author: David Engraf <david.engraf@sysgo.com>
    Date:   Thu Jan 3 15:28:31 2019 -0800

	initramfs: cleanup incomplete rootfs

	Unpacking an external initrd may fail e.g.  not enough memory.  This
	leads to an incomplete rootfs because some files might be extracted
	already.  Fixed by cleaning the rootfs so the kernel is not using an
	incomplete rootfs.

	Link: http://lkml.kernel.org/r/20181030151805.5519-1-david.engraf@sysgo.com
	Signed-off-by: David Engraf <david.engraf@sysgo.com>
	Cc: Dominik Brodowski <linux@dominikbrodowski.net>
	Cc: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
	Cc: Philippe Ombredanne <pombredanne@nexb.com>
	Cc: Arnd Bergmann <arnd@arndb.de>
	Cc: Luc Van Oostenryck <luc.vanoostenryck@gmail.com>
	Signed-off-by: Andrew Morton <akpm@linux-foundation.org>
	Signed-off-by: Linus Torvalds <torvalds@linux-foundation.org>