### PR TITLE
recipes-kernel/*/linux-linaro-qcomlt_5.1.bb: Dragonboard85c update to…

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.1.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.1.bb
@@ -11,7 +11,7 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "release/db845c/qcomlt-5.1"
-SRCREV ?= "5f45ef7de008123ffcc5d2433545e97861e19bcf"
+SRCREV ?= "28501e194c4716a59fd49e6ce3a462e337cc2d55"
 
 COMPATIBLE_MACHINE = "(sdm845)"
 


### PR DESCRIPTION
… rev 28501e194c471

Changes:

28501e194c471 usb: xhci: allow multiple firmware versions
e12ded63df8f5 usb: xhci: Add ROM loader for uPD720201
1ddb0b913a9d4 usb: xhci: Use register defined and field names
e73f333a18aa6 HACK: qcom: apr: Wait for PD up notification
0abfca0754c90 arm64: dts: qcom: sdm845-db845c: Specify UFS device-reset GPIO
0c3372c918350 arm64: dts: qcom: sdm845-mtp: Specify UFS device-reset GPIO
c01b5879564d8 scsi: ufs-qcom: Implement device_reset vops
55ea4de33885f scsi: ufs: Introduce vops for resetting device
bc8e07a9e07d7 pinctrl: qcom: sdm845: Expose ufs_reset as gpio

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>