### PR TITLE
recipes-kernel/*/linux-linaro-qcomlt_5.1.bb: Dragonboard845c update to…

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.1.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.1.bb
@@ -11,7 +11,7 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "release/db845c/qcomlt-5.1"
-SRCREV ?= "28501e194c4716a59fd49e6ce3a462e337cc2d55"
+SRCREV ?= "830dde589168e3ae46f2ff606de59972a69e868a"
 
 COMPATIBLE_MACHINE = "(sdm845)"
 


### PR DESCRIPTION
… rev 830dde589168e

Apply new version of XHCI USB patches,

Removed:

28501e194c471 usb: xhci: allow multiple firmware versions
e12ded63df8f5 usb: xhci: Add ROM loader for uPD720201
1ddb0b913a9d4 usb: xhci: Use register defined and field names

Added:

830dde589168e usb: xhci: allow multiple firmware versions
19d0a72e970bd usb: xhci: Add ROM loader for uPD720201
a9faf459d8de9 usb: xhci: Use register defined and field names
bfd9c0f7cf733 usb: xhci: fixes in firmware loader for uPD720201 and uPD720202 w/o ROM

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>