### PR TITLE
qdl: needs pkgconfig and udev

### DIFF
--- a/recipes-devtools/qdl/qdl_git.bb
+++ b/recipes-devtools/qdl/qdl_git.bb
@@ -5,7 +5,9 @@ SECTION = "devel"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://qdl.c;beginline=1;endline=31;md5=1c7d712d897368d3d3c161e5493efc6a"
 
-DEPENDS = "libxml2"
+DEPENDS = "libxml2 udev"
+
+inherit pkgconfig
 
 SRCREV = "760b3dffb03d2b7dfb82c6eac652a092f51c572d"
 SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https \


### PR DESCRIPTION
Fixes build issues e.g.
| qdl.c:43:10: fatal error: 'libudev.h' file not found
| #include <libudev.h>
|          ^~~~~~~~~~~

/bin/sh: pkg-config: command not found
patch.c:33:10: fatal error: libxml/parser.h: No such file or directory
   33 | #include <libxml/parser.h>
      |          ^~~~~~~~~~~~~~~~~

Signed-off-by: Khem Raj <raj.khem@gmail.com>