### PR TITLE
recipes-kernel/linux: Bump DB845c 5.2 kernel to b13017c21d

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.2.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.2.bb
@@ -11,7 +11,7 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "release/db845c/qcomlt-5.2"
-SRCREV ?= "70f66fea53de22302ebc1d36b5ce3c66331a1f51"
+SRCREV ?= "b13017c21d43cf5cbe81129c650ed5ed44d8adb0"
 
 COMPATIBLE_MACHINE = "(sdm845)"
 


### PR DESCRIPTION
Change,

b13017c21d43 arch/arm64/*/defconfig: Configure USB_XHCI_{PCI, HCD} as a module

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>