### PR TITLE
Add support for QCS404 based EVB4k platform

### DIFF
--- a/conf/machine/evb4k-qcs404.conf
+++ b/conf/machine/evb4k-qcs404.conf
@@ -1,0 +1,19 @@
+#@TYPE: Machine
+#@NAME: evb4k-qcs404
+#@DESCRIPTION: Machine configuration for the EVB-4K QCS404 with Qualcomm QCS404.
+
+require conf/machine/include/qcom-qcs404.inc
+require conf/machine/include/tune-cortexa53.inc
+
+MACHINE_FEATURES = "usbhost usbgadget ext2"
+
+KERNEL_IMAGETYPE ?= "Image.gz"
+KERNEL_DEVICETREE ?= "qcom/qcs404-evb-4000.dtb"
+
+SERIAL_CONSOLE ?= "115200 ttyMSM0"
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    kernel-modules \
+"
+
+QCOM_BOOTIMG_ROOTFS ?= "mmcblk0p27"

--- a/conf/machine/include/qcom-qcs404.inc
+++ b/conf/machine/include/qcom-qcs404.inc
@@ -1,0 +1,16 @@
+SOC_FAMILY = "qcs404"
+require conf/machine/include/soc-family.inc
+require conf/machine/include/arm/arch-armv8a.inc
+
+PREFERRED_PROVIDER_virtual/kernel ?= "linux-linaro-qcomlt"
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    qrtr \
+"
+
+# Fastboot expects an ext4 image, which needs to be 4096 aligned
+IMAGE_FSTYPES ?= "ext4.gz"
+IMAGE_ROOTFS_ALIGNMENT = "4096"
+
+QCOM_BOOTIMG_KERNEL_BASE ?= "0x80000000"
+QCOM_BOOTIMG_PAGE_SIZE ?= "4096"

--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.2.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.2.bb
@@ -13,7 +13,7 @@ LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "release/db845c/qcomlt-5.2"
 SRCREV ?= "b062b8936709168c9159849e83bfd2f60d95afd6"
 
-COMPATIBLE_MACHINE = "(sdm845)"
+COMPATIBLE_MACHINE = "(sdm845|qcs404)"
 
 # Wifi firmware has a recognizable arch :( 
 ERROR_QA_remove = "arch"


### PR DESCRIPTION
EVB4K is a Qcom platform based on QCS404 based SOC. This patch adds basic support.

Signed-off-by: Khasim Syed Mohammed <khasim.mohammed@linaro.org>
