### PR TITLE
tqftpserv: Fix build on musl

### DIFF
--- a/recipes-support/tqftpserv/tqftpserv/0001-include-limits.h-for-PATH_MAX.patch
+++ b/recipes-support/tqftpserv/tqftpserv/0001-include-limits.h-for-PATH_MAX.patch
@@ -1,0 +1,25 @@
+From c21250e08cc5e6815340244693437e6372b5eca4 Mon Sep 17 00:00:00 2001
+From: Khem Raj <raj.khem@gmail.com>
+Date: Fri, 29 Nov 2019 17:52:33 -0800
+Subject: [PATCH] include limits.h for PATH_MAX
+
+Signed-off-by: Khem Raj <raj.khem@gmail.com>
+---
+ translate.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/translate.c b/translate.c
+index 34c419e..e95dee5 100644
+--- a/translate.c
++++ b/translate.c
+@@ -35,6 +35,7 @@
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <libgen.h>
++#include <limits.h>
+ #include <stdio.h>
+ #include <string.h>
+ #include <unistd.h>
+-- 
+2.24.0
+

--- a/recipes-support/tqftpserv/tqftpserv_git.bb
+++ b/recipes-support/tqftpserv/tqftpserv_git.bb
@@ -10,7 +10,9 @@ DEPENDS = "qrtr"
 inherit systemd
 
 SRCREV = "fe53d2a810abe0e1ee7cc0bb20fd520dc6605ecb"
-SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https"
+SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https \
+           file://0001-include-limits.h-for-PATH_MAX.patch \
+"
 
 PV = "0.0+${SRCPV}"
 


### PR DESCRIPTION
Proposed upstream see

https://github.com/andersson/tqftpserv/pull/4

but I wonder if such recipes should be in meta-oe and not stashed into  BSP layers