### PR TITLE
conf/machine: Update rootfs partition in dragonboard-410c

### DIFF
--- a/conf/machine/dragonboard-410c.conf
+++ b/conf/machine/dragonboard-410c.conf
@@ -20,7 +20,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     firmware-qcom-dragonboard410c \
 "
 
-QCOM_BOOTIMG_ROOTFS ?= "mmcblk0p10"
+QCOM_BOOTIMG_ROOTFS ?= "mmcblk0p14"
 
 # Define rootfs partiton (kernel argument)
 SD_QCOM_BOOTIMG_ROOTFS ?= "mmcblk1p7"


### PR DESCRIPTION
New bootloader comes with new partitions to store rmtfs firmware [1].

[1] https://git.linaro.org/landing-teams/working/qualcomm/db-boot-tools.git/commit/?id=04008fd6570b566041e6ded5df738068416607e3

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>