### PR TITLE
[sumo] Cherry-pick update to rootfs partition in dragonboard-410c

### DIFF
--- a/conf/machine/dragonboard-410c.conf
+++ b/conf/machine/dragonboard-410c.conf
@@ -20,7 +20,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     firmware-qcom-dragonboard410c \
 "
 
-QCOM_BOOTIMG_ROOTFS ?= "mmcblk0p10"
+QCOM_BOOTIMG_ROOTFS ?= "mmcblk0p14"
 
 # Define rootfs partiton (kernel argument)
 SD_QCOM_BOOTIMG_ROOTFS ?= "mmcblk1p7"


### PR DESCRIPTION
This change has been applied to other branches already. Applying it in Sumo will enable LKFT builds to use the new partition table on the LAVA devices that bear that tag.