### PR TITLE
recipes-bsp/firmware: Install dragonboard820c adsp firmware inside qc…

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-dragonboard820c_01700.1.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard820c_01700.1.bb
@@ -19,10 +19,11 @@ do_compile() {
 do_install() {
     install -d ${D}${nonarch_base_libdir}/firmware/
     install -d ${D}${nonarch_base_libdir}/firmware/qcom/venus-4.2/
+    install -d ${D}${nonarch_base_libdir}/firmware/qcom/msm8996/
     
     install -m 0444 ./proprietary-linux/a530*.* ${D}${nonarch_base_libdir}/firmware/
     install -m 0444 ./proprietary-linux/venus.* ${D}${nonarch_base_libdir}/firmware/qcom/venus-4.2/
-    install -m 0444 ./proprietary-linux/adsp.* ${D}${nonarch_base_libdir}/firmware/
+    install -m 0444 ./proprietary-linux/adsp.* ${D}${nonarch_base_libdir}/firmware/qcom/msm8996/
 
     install -d ${D}${sysconfdir}/
     install -m 0644 LICENSE ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE


### PR DESCRIPTION
The 5.4 kernel module looks into __FIRMWARE_DIR__/qcom/msm8996 to load
adsp firmware.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>