### PR TITLE
recipes-kernel: Linux 5.4 bump to 37a87299c862

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.4.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.4.bb
@@ -9,7 +9,7 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "release/qcomlt-5.4"
-SRCREV ?= "8a9b29362e55e16171a30705207f350ac23cb3a2"
+SRCREV ?= "37a87299c86289371173ba70c186b9201ba0f4fc"
 
 COMPATIBLE_MACHINE = "(apq8016|apq8096|sdm845)"
 


### PR DESCRIPTION
Changes,

37a87299c862 distro.config: Enable OV5640 and OV5645 drivers
7a62aa18349e arm64: defconfig: Enable QCOM CAMSS and CCI drivers
4a61ef69c042 arm64: dts: apq8016-sbc: Add camera cci/sensor nodes
837e4f15505a arm64: dts: msm8916: Add CCI node
4a3cf895cab7 dt-bindings: i2c: Add binding for Qualcomm CCI I2C controller
334988bca574 i2c: Add Qualcomm CCI I2C driver
628ec7ef3004 media: ov5640: add PIXEL_RATE control

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>