### PR TITLE
recipes-kernel/linux: Linux 5.4 bump to rev 447814278e3f

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.4.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.4.bb
@@ -9,7 +9,7 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "release/qcomlt-5.4"
-SRCREV ?= "37a87299c86289371173ba70c186b9201ba0f4fc"
+SRCREV ?= "447814278e3fcaef6db32a458e976b8c0c30ea0d"
 
 COMPATIBLE_MACHINE = "(apq8016|apq8096|sdm845)"
 


### PR DESCRIPTION
Fixes,

447814278e3f remoteproc: qcom: wcnss: Add iris completion barrier

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>