### PR TITLE
initramfs-test-image: Add useful utilities for testing

### DIFF
--- a/recipes-test/images/initramfs-test-image.bb
+++ b/recipes-test/images/initramfs-test-image.bb
@@ -2,6 +2,7 @@ DESCRIPTION = "Small ramdisk image for running tests (bootrr, etc)"
 
 PACKAGE_INSTALL = " \
     ${ROOTFS_BOOTSTRAP_INSTALL} \
+    bluez5 \
     busybox \
     base-passwd \
     devmem2 \
@@ -12,10 +13,15 @@ PACKAGE_INSTALL = " \
     iperf3 \
     lava-test-shell \
     packagegroup-core-boot \
+    pciutils \
+    pd-mapper \
     qrtr \
     rmtfs \
     tcpdump \
+    tqftpserv \
     udev \
+    usbutils \
+    wpa-supplicant \
 "
 
 # Do not pollute the initrd image with rootfs features


### PR DESCRIPTION
Add bluez package to allow validation of bluetooth support, pciutils to
get lspci, pd-mapper and tqftpserv to allow booting the WiFi firmware,
usbutils for lsusb and wpa-supplicant to allow basic testing of the
WiFi support.

Signed-off-by: Bjorn Andersson <bjorn.andersson@linaro.org>