### PR TITLE
recipes-test/images: Add dhcp to initramfs-test-image

### DIFF
--- a/recipes-test/images/initramfs-test-image.bb
+++ b/recipes-test/images/initramfs-test-image.bb
@@ -5,6 +5,7 @@ PACKAGE_INSTALL = " \
     bluez5 \
     busybox \
     base-passwd \
+    dhcp-client \
     diag \
     ethtool \
     gptfdisk \


### PR DESCRIPTION
Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>