### PR TITLE
Enable WiFi on dragonboard845c

### DIFF
--- a/conf/machine/dragonboard-845c.conf
+++ b/conf/machine/dragonboard-845c.conf
@@ -14,8 +14,11 @@ SERIAL_CONSOLE ?= "115200 ttyMSM0"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     firmware-qcom-dragonboard845c \
     kernel-modules \
+    linux-firmware-qcom-sdm845-audio \
+    linux-firmware-qcom-sdm845-compute \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k linux-firmware-qcom-sdm845-modem', '', d)} \
 "
 
 # /dev/sda1 is 'rootfs' partition after installing the latest bootloader package from linaro

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard845c/generate_board-2_json.sh
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard845c/generate_board-2_json.sh
@@ -1,0 +1,23 @@
+JSON="$2"
+
+iter=0
+echo "[" > "${JSON}"
+for file in $1/bdwlan.*; do
+    [[ $file == *.txt ]] && continue
+
+    iter=$((iter+1))
+    [ $iter -ne 1 ] && echo "  }," >> "${JSON}"
+
+    echo "  {" >> "${JSON}"
+    echo "          \"data\": \"$file\"," >> "${JSON}"
+    if [[ $file == */bdwlan.bin ]]; then
+        file_ext="ff"
+    else
+        file_ext="$(printf '%x\n' "$(basename "${file}" | sed -E 's:^.*\.b?([0-9a-f]*)$:0x\1:')")"
+    fi
+    echo "          \"names\": [\"bus=snoc,qmi-board-id=${file_ext}\"]" >> "${JSON}"
+done
+
+echo "  }" >> "${JSON}"
+echo "]" >> "${JSON}"
+

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
@@ -3,31 +3,42 @@ DESCRIPTION = "QCOM Firmware for DragonBoard 845c"
 LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://LICENSE.qcom.txt;md5=cbbe399f2c983ad51768f4561587f000"
 
-SRC_URI = "https://releases.linaro.org/96boards/dragonboard845c/qualcomm/firmware/RB3_firmware_${PV}.zip"
+SRC_URI = "https://releases.linaro.org/96boards/dragonboard845c/qualcomm/firmware/RB3_firmware_${PV}.zip \
+           git://github.com/qca/qca-swiss-army-knife \
+           file://generate_board-2_json.sh"
 SRC_URI[md5sum] = "ad69855a1275547b16d94a1b5405ac62"
 SRC_URI[sha256sum] = "4289d2f2a7124b104d0274879e702aae9b1e50c42eec3747f8584c6744ef65e3"
+SRCREV = "4d397963b1750e8839c0c26d197bee2e1417cbf2"
 
 COMPATIBLE_MACHINE = "(dragonboard-845c)"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
+DEPENDS += "bash-native"
+inherit pythonnative
 
 S = "${WORKDIR}"
 
 do_compile() {
-	:
+    # Build board-2.bin needed by WiFi
+    mkdir -p bdf
+    cp ./38-bdwlan_split/bdwlan*.* bdf
+    bash generate_board-2_json.sh bdf board-2.json
+    python2 git/tools/scripts/ath10k/ath10k-bdencoder -c board-2.json -o board-2.bin
 }
 
 do_install() {
     install -d ${D}${nonarch_base_libdir}/firmware/
     install -d ${D}${nonarch_base_libdir}/firmware/qcom/venus-5.2/
     install -d ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
+    install -d ${D}${nonarch_base_libdir}/firmware/ath10k/WCN3990/hw1.0/
 
     install -m 0444 ./17-USB3-201-202-FW/K2026090.mem ${D}${nonarch_base_libdir}/firmware/
     install -m 0444 ./18-adreno-fw/a630*.* ${D}${nonarch_base_libdir}/firmware/
     install -m 0444 ./20-adsp_split/firmware/adsp*.* ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
     install -m 0444 ./21-cdsp_split/firmware/cdsp*.* ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
     install -m 0444 ./33-venus_split/venus.* ${D}${nonarch_base_libdir}/firmware/qcom/venus-5.2/
-    install -m 0444 ./37-wlan_FW/wlanmdsp.mbn ${D}${nonarch_base_libdir}/firmware/
-    install -m 0444 ./38-bdwlan_split/bdwlan*.* ${D}${nonarch_base_libdir}/firmware/
+
+    install -m 0444 ./board-2.bin ${D}${nonarch_base_libdir}/firmware/ath10k/WCN3990/hw1.0/
+    ln -sf ../../ath10k/WCN3990/hw1.0/wlanmdsp.mbn ${D}${nonarch_base_libdir}/firmware/qcom/sdm845/wlanmdsp.mbn
 
     install -d ${D}${sysconfdir}/
     install -m 0644 LICENSE.qcom.txt ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE

--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.4.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.4.bb
@@ -11,7 +11,7 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "release/qcomlt-5.4"
-SRCREV ?= "8c79b3d123550fde184d9ef6b3d5e2e530abe0bd"
+SRCREV ?= "51ca02ab1dbe7f70152631b09d991b668ecc0214"
 
 COMPATIBLE_MACHINE = "(apq8016|apq8096|sdm845)"
 


### PR DESCRIPTION
It depends on https://review.linaro.org/c/openembedded/meta-backports/+/34665 to add linux-firmware-qcom-sdm845.

Regarding master only last patch needs to wait until merge linux-firmware-qcom-sdm845 packages in OE master.