### PR TITLE
recipes-kernel: Linux 5.7 bump to 5.7.2 (ba75ed77ea9e)

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.7.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.7.bb
@@ -11,7 +11,7 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "release/qcomlt-5.7"
-SRCREV ?= "209751f3ff3e1bde123f6d1261269ca85c1f838c"
+SRCREV ?= "ba75ed77ea9ee88706bd1b78512f4f86040feb6c"
 
 COMPATIBLE_MACHINE = "(apq8016|apq8096|sdm845)"
 


### PR DESCRIPTION
Changes,

ba75ed77ea9e Merge tag 'v5.7.2' into release/qcomlt-5.7
8b0853ff4472 Merge branch 'tracking-qcomlt-lt9611' into release/qcomlt-5.7
8ee534ec8a56 drm/bridge: Introduce LT9611 DSI to HDMI bridge
7636286afbd1 dt-bindings: display: bridge: Add documentation for LT9611
9250431bb3b5 dt-bindings: vendor-prefixes: Add Lontium vendor prefix

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>
(cherry picked from commit 44d01caa4783d14fd53cc6c61308acb3c1e31d86)
Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>