### PR TITLE
recipes-kernel: Linux 5.7 bump to 5.7.3 (a7ce3355155d)

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.7.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.7.bb
@@ -11,7 +11,7 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "release/qcomlt-5.7"
-SRCREV ?= "ba75ed77ea9ee88706bd1b78512f4f86040feb6c"
+SRCREV ?= "a7ce3355155d92aeee3d17d11bceb6d8547045d8"
 
 COMPATIBLE_MACHINE = "(apq8016|apq8096|sdm845)"
 


### PR DESCRIPTION
Changes,

a7ce3355155d Merge tag 'v5.7.3' into release/qcomlt-5.7
...
9aff2dcc27eb wcn36xx: Fix multiple AMPDU sessions support
44e6ad37e04a wcn36xx: Add ieee80211 rx status rate information

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>