### PR TITLE
Remove venus fw install from firmware-qcom-dragonboard845c recipe

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
@@ -27,14 +27,12 @@ do_compile() {
 
 do_install() {
     install -d ${D}${nonarch_base_libdir}/firmware/
-    install -d ${D}${nonarch_base_libdir}/firmware/qcom/venus-5.2/
     install -d ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
 
     install -m 0444 ./17-USB3-201-202-FW/K2026090.mem ${D}${nonarch_base_libdir}/firmware/
     install -m 0444 ./18-adreno-fw/a630_zap*.* ${D}${nonarch_base_libdir}/firmware/qcom/
     install -m 0444 ./20-adsp_split/firmware/adsp*.* ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
     install -m 0444 ./21-cdsp_split/firmware/cdsp*.* ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
-    install -m 0444 ./33-venus_split/venus.* ${D}${nonarch_base_libdir}/firmware/qcom/venus-5.2/
 
     install -d ${D}${nonarch_base_libdir}/firmware/ath10k/WCN3990/hw1.0/
     install -m 0444 ./board-2.bin ${D}${nonarch_base_libdir}/firmware/ath10k/WCN3990/hw1.0/
@@ -45,10 +43,6 @@ do_install() {
 
 FILES_${PN} += "${nonarch_base_libdir}/firmware/*"
 INSANE_SKIP_${PN} += "arch"
-
-RPROVIDES_${PN} += "linux-firmware-qcom-venus-5.2"
-RREPLACES_${PN} += "linux-firmware-qcom-venus-5.2"
-RCONFLICTS_${PN} += "linux-firmware-qcom-venus-5.2"
 
 RPROVIDES_${PN} += "linux-firmware-qcom-license"
 RREPLACES_${PN} += "linux-firmware-qcom-license"


### PR DESCRIPTION
The linux-firmware package complains that venus fw is supplied by both
linux-firmware and firmware-qcom-dragonboard845c.

The linux-firmware recipe is actually ambiguous in the sense that it doesn't
list the venus-5.2 package in the recipe, but does install it alongside all
the other firmware in the do_install part of the recipe.

Collected errors:
 * check_data_file_clashes: Package linux-firmware wants to install file /workdir/build/tmp-glibc/work/dragonboard_845c-linux/rb3-image-dev/9999.1-r0/rootfs/lib/firmware/qcom/venus-5.2/venus.b00
	But that file is already provided by package  * firmware-qcom-dragonboard845c
 * check_data_file_clashes: Package linux-firmware wants to install file /workdir/build/tmp-glibc/work/dragonboard_845c-linux/rb3-image-dev/9999.1-r0/rootfs/lib/firmware/qcom/venus-5.2/venus.b01
	But that file is already provided by package  * firmware-qcom-dragonboard845c
 * check_data_file_clashes: Package linux-firmware wants to install file /workdir/build/tmp-glibc/work/dragonboard_845c-linux/rb3-image-dev/9999.1-r0/rootfs/lib/firmware/qcom/venus-5.2/venus.b02
	But that file is already provided by package  * firmware-qcom-dragonboard845c
 * check_data_file_clashes: Package linux-firmware wants to install file /workdir/build/tmp-glibc/work/dragonboard_845c-linux/rb3-image-dev/9999.1-r0/rootfs/lib/firmware/qcom/venus-5.2/venus.b03
	But that file is already provided by package  * firmware-qcom-dragonboard845c
 * check_data_file_clashes: Package linux-firmware wants to install file /workdir/build/tmp-glibc/work/dragonboard_845c-linux/rb3-image-dev/9999.1-r0/rootfs/lib/firmware/qcom/venus-5.2/venus.b04
	But that file is already provided by package  * firmware-qcom-dragonboard845c
 * check_data_file_clashes: Package linux-firmware wants to install file /workdir/build/tmp-glibc/work/dragonboard_845cp-linux/rb3-image-dev/9999.1-r0/rootfs/lib/firmware/qcom/venus-5.2/venus.mdt
	But that file is already provided by package  * firmware-qcom-dragonboard845c

Signed-off-by: Olivier Schonken <olivier.schonken@gmail.com>