### PR TITLE
Remove broken venus-5.2 and venus-5.4 from linux-firmware

### DIFF
--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,0 +1,7 @@
+
+do_install_append() {
+        rm -rf ${D}${nonarch_base_libdir}/firmware/qcom/venus-5.2
+        rm -rf ${D}${nonarch_base_libdir}/firmware/qcom/venus-5.4
+}
+
+


### PR DESCRIPTION
The linux-firmware package complains that venus fw is supplied by both
linux-firmware and firmware-qcom-dragonboard845c. The venus firmware
supplied by linux-firmware is broken. This patch removes the installed
files for venus-5.2 and venus-5.4 which is not explicitly listed in
the linux-firmware recipe from openembedded.

The linux-firmware recipe is actually ambiguous in the sense that it doesn't
list the venus-5.2 package in the recipe, but does install it alongside all
the other firmware in the do_install part of the recipe.

Collected errors:

check_data_file_clashes: Package linux-firmware wants to install file /workdir/build/tmp-glibc/work/dragonboard_845c-linux/rb3-image-dev/9999.1-r0/rootfs/lib/firmware/qcom/venus-5.2/venus.b00
But that file is already provided by package * firmware-qcom-dragonboard845c
check_data_file_clashes: Package linux-firmware wants to install file /workdir/build/tmp-glibc/work/dragonboard_845c-linux/rb3-image-dev/9999.1-r0/rootfs/lib/firmware/qcom/venus-5.2/venus.b01
But that file is already provided by package * firmware-qcom-dragonboard845c
check_data_file_clashes: Package linux-firmware wants to install file /workdir/build/tmp-glibc/work/dragonboard_845c-linux/rb3-image-dev/9999.1-r0/rootfs/lib/firmware/qcom/venus-5.2/venus.b02
But that file is already provided by package * firmware-qcom-dragonboard845c
check_data_file_clashes: Package linux-firmware wants to install file /workdir/build/tmp-glibc/work/dragonboard_845c-linux/rb3-image-dev/9999.1-r0/rootfs/lib/firmware/qcom/venus-5.2/venus.b03
But that file is already provided by package * firmware-qcom-dragonboard845c
check_data_file_clashes: Package linux-firmware wants to install file /workdir/build/tmp-glibc/work/dragonboard_845c-linux/rb3-image-dev/9999.1-r0/rootfs/lib/firmware/qcom/venus-5.2/venus.b04
But that file is already provided by package * firmware-qcom-dragonboard845c
check_data_file_clashes: Package linux-firmware wants to install file /workdir/build/tmp-glibc/work/dragonboard_845cp-linux/rb3-image-dev/9999.1-r0/rootfs/lib/firmware/qcom/venus-5.2/venus.mdt
But that file is already provided by package * firmware-qcom-dragonboard845c

Signed-off-by: Olivier Schonken <olivier.schonken@gmail.com>