### PR TITLE
recipes-kernel: Linux 5.7 bump to 5.7.5 (37b31489130d)

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.7.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.7.bb
@@ -11,7 +11,7 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "release/qcomlt-5.7"
-SRCREV ?= "a7ce3355155d92aeee3d17d11bceb6d8547045d8"
+SRCREV ?= "37b31489130dbeb8fa89dc99e8ff99c80fa264e0"
 
 COMPATIBLE_MACHINE = "(apq8016|apq8096|sdm845)"
 


### PR DESCRIPTION
Changes,

37b31489130d wcn36xx: Fix software-driven scan
9e5c701f0dc6 wcn36xx: Advertise beacon filtering support in bmps
f0076ecebddf mac80211: Do not report beacon loss if beacon filtering enabled
d5ffda0bd43b Merge tag 'v5.7.5' into release/qcomlt-5.7

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>