### PR TITLE
RB5 support

### DIFF
--- a/conf/machine/qrb5165-rb5.conf
+++ b/conf/machine/qrb5165-rb5.conf
@@ -1,0 +1,25 @@
+#@TYPE: Machine
+#@NAME: RB5 Robotics platform
+#@DESCRIPTION: Machine configuration for the RB5 development board, with Qualcomm Snapdragon 865 QRB5165.
+
+require conf/machine/include/qcom-sm8250.inc
+
+MACHINE_FEATURES = "usbhost usbgadget alsa screen wifi bluetooth ext2"
+
+KERNEL_IMAGETYPE ?= "Image.gz"
+KERNEL_DEVICETREE ?= "qcom/qrb5165-rb5.dtb"
+
+SERIAL_CONSOLE ?= "115200 ttyMSM0"
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    kernel-modules \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \
+"
+# linux-firmware-qcom-adreno-a650 
+
+# /dev/sda15 is 'userdata' partition, so wipe it and use for our build
+QCOM_BOOTIMG_ROOTFS ?= "sda15"
+
+# UFS partitions setup with 4096 logical sector size
+EXTRA_IMAGECMD_ext4 += " -b 4096 "

--- a/recipes-kernel/linux/linux-linaro-qcomlt-5.7/0001-arm64-dts-qcom-sm8250-Add-USB-and-PHY-device-nodes.patch
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-5.7/0001-arm64-dts-qcom-sm8250-Add-USB-and-PHY-device-nodes.patch
@@ -1,0 +1,207 @@
+From e4a349e3fce09e441f6568ca318be66709386514 Mon Sep 17 00:00:00 2001
+From: Jonathan Marek <jonathan@marek.ca>
+Date: Tue, 9 Jun 2020 15:40:24 -0400
+Subject: [PATCH] arm64: dts: qcom: sm8250: Add USB and PHY device nodes
+
+Add device nodes for the USB3 controller, QMP SS PHY and
+SNPS HS PHY.
+
+Signed-off-by: Jonathan Marek <jonathan@marek.ca>
+---
+ arch/arm64/boot/dts/qcom/sm8250.dtsi | 180 +++++++++++++++++++++++++++
+ 1 file changed, 180 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/sm8250.dtsi b/arch/arm64/boot/dts/qcom/sm8250.dtsi
+index cc6c65883d88..68f9a3ce9760 100644
+--- a/arch/arm64/boot/dts/qcom/sm8250.dtsi
++++ b/arch/arm64/boot/dts/qcom/sm8250.dtsi
+@@ -1097,6 +1097,186 @@ intc: interrupt-controller@17a00000 {
+ 			interrupts = <GIC_PPI 9 IRQ_TYPE_LEVEL_HIGH>;
+ 		};
+ 
++		usb_1_hsphy: phy@88e3000 {
++			compatible = "qcom,sm8250-usb-hs-phy",
++				     "qcom,usb-snps-hs-7nm-phy";
++			reg = <0 0x088e3000 0 0x400>;
++			status = "disabled";
++			#phy-cells = <0>;
++
++			clocks = <&rpmhcc RPMH_CXO_CLK>;
++			clock-names = "ref";
++
++			resets = <&gcc GCC_QUSB2PHY_PRIM_BCR>;
++		};
++
++		usb_2_hsphy: phy@88e4000 {
++			compatible = "qcom,sm8250-usb-hs-phy",
++				     "qcom,usb-snps-hs-7nm-phy";
++			reg = <0 0x088e4000 0 0x400>;
++			status = "disabled";
++			#phy-cells = <0>;
++
++			clocks = <&rpmhcc RPMH_CXO_CLK>;
++			clock-names = "ref";
++
++			resets = <&gcc GCC_QUSB2PHY_SEC_BCR>;
++		};
++
++		usb_1_qmpphy: phy@88e9000 {
++			compatible = "qcom,sm8250-qmp-usb3-phy";
++			reg = <0 0x088e9000 0 0x200>,
++			      <0 0x088e8000 0 0x20>;
++			reg-names = "reg-base", "dp_com";
++			status = "disabled";
++			#clock-cells = <1>;
++			#address-cells = <2>;
++			#size-cells = <2>;
++			ranges;
++
++			clocks = <&gcc GCC_USB3_PRIM_PHY_AUX_CLK>,
++				 <&rpmhcc RPMH_CXO_CLK>,
++				 <&gcc GCC_USB3_PRIM_PHY_COM_AUX_CLK>;
++			clock-names = "aux", "ref_clk_src", "com_aux";
++
++			resets = <&gcc GCC_USB3_DP_PHY_PRIM_BCR>,
++				 <&gcc GCC_USB3_PHY_PRIM_BCR>;
++			reset-names = "phy", "common";
++
++			usb_1_ssphy: lanes@88e9200 {
++				reg = <0 0x088e9200 0 0x200>,
++				      <0 0x088e9400 0 0x200>,
++				      <0 0x088e9c00 0 0x400>,
++				      <0 0x088e9600 0 0x200>,
++				      <0 0x088e9800 0 0x200>,
++				      <0 0x088e9a00 0 0x100>;
++				#phy-cells = <0>;
++				clocks = <&gcc GCC_USB3_PRIM_PHY_PIPE_CLK>;
++				clock-names = "pipe0";
++				clock-output-names = "usb3_phy_pipe_clk_src";
++			};
++		};
++
++		usb_2_qmpphy: phy@88eb000 {
++			compatible = "qcom,sm8250-qmp-usb3-uni-phy";
++			reg = <0 0x088eb000 0 0x200>;
++			status = "disabled";
++			#clock-cells = <1>;
++			#address-cells = <2>;
++			#size-cells = <2>;
++			ranges;
++
++			clocks = <&gcc GCC_USB3_SEC_PHY_AUX_CLK>,
++				 <&rpmhcc RPMH_CXO_CLK>,
++				 <&gcc GCC_USB3_SEC_CLKREF_EN>,
++				 <&gcc GCC_USB3_SEC_PHY_COM_AUX_CLK>;
++			clock-names = "aux", "ref_clk_src", "ref", "com_aux";
++
++			resets = <&gcc GCC_USB3PHY_PHY_SEC_BCR>,
++				 <&gcc GCC_USB3_PHY_SEC_BCR>;
++			reset-names = "phy", "common";
++
++			usb_2_ssphy: lane@88eb200 {
++				reg = <0 0x088eb200 0 0x200>,
++				      <0 0x088eb400 0 0x200>,
++				      <0 0x088eb800 0 0x800>;
++				#phy-cells = <0>;
++				clocks = <&gcc GCC_USB3_SEC_PHY_PIPE_CLK>;
++				clock-names = "pipe0";
++				clock-output-names = "usb3_uni_phy_pipe_clk_src";
++			};
++		};
++
++		usb_1: usb@a6f8800 {
++			compatible = "qcom,sm8250-dwc3", "qcom,dwc3";
++			reg = <0 0x0a6f8800 0 0x400>;
++			status = "disabled";
++			#address-cells = <2>;
++			#size-cells = <2>;
++			ranges;
++			dma-ranges;
++
++			clocks = <&gcc GCC_CFG_NOC_USB3_PRIM_AXI_CLK>,
++				 <&gcc GCC_USB30_PRIM_MASTER_CLK>,
++				 <&gcc GCC_AGGRE_USB3_PRIM_AXI_CLK>,
++				 <&gcc GCC_USB30_PRIM_MOCK_UTMI_CLK>,
++				 <&gcc GCC_USB30_PRIM_SLEEP_CLK>,
++				 <&gcc GCC_USB3_SEC_CLKREF_EN>;
++			clock-names = "cfg_noc", "core", "iface", "mock_utmi",
++				      "sleep", "xo";
++
++			assigned-clocks = <&gcc GCC_USB30_PRIM_MOCK_UTMI_CLK>,
++					  <&gcc GCC_USB30_PRIM_MASTER_CLK>;
++			assigned-clock-rates = <19200000>, <200000000>;
++
++			interrupts-extended = <&intc GIC_SPI 131 IRQ_TYPE_LEVEL_HIGH>,
++					      <&pdc 14 IRQ_TYPE_EDGE_BOTH>,
++					      <&pdc 15 IRQ_TYPE_EDGE_BOTH>,
++					      <&pdc 17 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "hs_phy_irq", "dp_hs_phy_irq",
++					  "dm_hs_phy_irq", "ss_phy_irq";
++
++			power-domains = <&gcc USB30_PRIM_GDSC>;
++
++			resets = <&gcc GCC_USB30_PRIM_BCR>;
++
++			usb_1_dwc3: dwc3@a600000 {
++				compatible = "snps,dwc3";
++				reg = <0 0x0a600000 0 0xcd00>;
++				interrupts = <GIC_SPI 133 IRQ_TYPE_LEVEL_HIGH>;
++				//iommus = <&apps_smmu 0x0 0x0>;
++				snps,dis_u2_susphy_quirk;
++				snps,dis_enblslpm_quirk;
++				phys = <&usb_1_hsphy>, <&usb_1_ssphy>;
++				phy-names = "usb2-phy", "usb3-phy";
++			};
++		};
++
++		usb_2: usb@a8f8800 {
++			compatible = "qcom,sm8250-dwc3", "qcom,dwc3";
++			reg = <0 0x0a8f8800 0 0x400>;
++			status = "disabled";
++			#address-cells = <2>;
++			#size-cells = <2>;
++			ranges;
++			dma-ranges;
++
++			clocks = <&gcc GCC_CFG_NOC_USB3_SEC_AXI_CLK>,
++				 <&gcc GCC_USB30_SEC_MASTER_CLK>,
++				 <&gcc GCC_AGGRE_USB3_SEC_AXI_CLK>,
++				 <&gcc GCC_USB30_SEC_MOCK_UTMI_CLK>,
++				 <&gcc GCC_USB30_SEC_SLEEP_CLK>,
++				 <&gcc GCC_USB3_SEC_CLKREF_EN>;
++			clock-names = "cfg_noc", "core", "iface", "mock_utmi",
++				      "sleep", "xo";
++
++			assigned-clocks = <&gcc GCC_USB30_SEC_MOCK_UTMI_CLK>,
++					  <&gcc GCC_USB30_SEC_MASTER_CLK>;
++			assigned-clock-rates = <19200000>, <200000000>;
++
++			interrupts-extended = <&intc GIC_SPI 136 IRQ_TYPE_LEVEL_HIGH>,
++					      <&pdc 12 IRQ_TYPE_EDGE_BOTH>,
++					      <&pdc 13 IRQ_TYPE_EDGE_BOTH>,
++					      <&pdc 16 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "hs_phy_irq", "dp_hs_phy_irq",
++					  "dm_hs_phy_irq", "ss_phy_irq";
++
++			power-domains = <&gcc USB30_SEC_GDSC>;
++
++			resets = <&gcc GCC_USB30_SEC_BCR>;
++
++			usb_2_dwc3: dwc3@a800000 {
++				compatible = "snps,dwc3";
++				reg = <0 0x0a800000 0 0xcd00>;
++				interrupts = <GIC_SPI 138 IRQ_TYPE_LEVEL_HIGH>;
++				//iommus = <&apps_smmu 0x20 0>;
++				snps,dis_u2_susphy_quirk;
++				snps,dis_enblslpm_quirk;
++				phys = <&usb_2_hsphy>, <&usb_2_ssphy>;
++				phy-names = "usb2-phy", "usb3-phy";
++			};
++		};
++
+ 		pdc: interrupt-controller@b220000 {
+ 			compatible = "qcom,sm8250-pdc", "qcom,pdc";
+ 			reg = <0 0x0b220000 0 0x30000>, <0 0x17c000f0 0 0x60>;
+-- 
+2.27.0
+

--- a/recipes-kernel/linux/linux-linaro-qcomlt-5.7/0001-arm64-dts-qcom-sm8250-Add-support-for-SDC2.patch
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-5.7/0001-arm64-dts-qcom-sm8250-Add-support-for-SDC2.patch
@@ -1,0 +1,45 @@
+From a1b05da240efec1780dc654dd12efe518e4a5068 Mon Sep 17 00:00:00 2001
+From: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
+Date: Tue, 9 Jun 2020 11:10:58 +0530
+Subject: [PATCH] arm64: dts: qcom: sm8250: Add support for SDC2
+
+Add support for SDC2 which can be used to interface uSD card.
+
+Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
+---
+ arch/arm64/boot/dts/qcom/sm8250.dtsi | 19 +++++++++++++++++++
+ 1 file changed, 19 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/sm8250.dtsi b/arch/arm64/boot/dts/qcom/sm8250.dtsi
+index 68f9a3ce9760..8e4abe5aa01f 100644
+--- a/arch/arm64/boot/dts/qcom/sm8250.dtsi
++++ b/arch/arm64/boot/dts/qcom/sm8250.dtsi
+@@ -983,6 +983,25 @@ ufs_mem_phy_lanes: lanes@1d87400 {
+ 			};
+ 		};
+ 
++		sdhc_2: sdhci@8804000 {
++			compatible = "qcom,sm8250-sdhci", "qcom,sdhci-msm-v5";
++			reg = <0 0x08804000 0 0x1000>;
++
++			interrupts = <GIC_SPI 204 IRQ_TYPE_LEVEL_HIGH>,
++				     <GIC_SPI 222 IRQ_TYPE_LEVEL_HIGH>;
++			interrupt-names = "hc_irq", "pwr_irq";
++
++			clocks = <&gcc GCC_SDCC2_AHB_CLK>,
++				 <&gcc GCC_SDCC2_APPS_CLK>;
++			clock-names = "iface", "core";
++			//iommus = <&apps_smmu 0xa0 0xf>;
++			qcom,dll-config = <0x0007642c>;
++			qcom,ddr-config = <0x80040868>;
++			power-domains = <&rpmhpd SM8250_CX>;
++
++			status = "disabled";
++		};
++
+ 		intc: interrupt-controller@17a00000 {
+ 			compatible = "arm,gic-v3";
+ 			#interrupt-cells = <3>;
+-- 
+2.27.0
+

--- a/recipes-kernel/linux/linux-linaro-qcomlt-5.7/0001-arm64-dts-qcom-sm8250-Rename-UART2-node-to-UART12.patch
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-5.7/0001-arm64-dts-qcom-sm8250-Rename-UART2-node-to-UART12.patch
@@ -1,0 +1,74 @@
+From 7239ad605113c0945c94f0f75cfbeb3b1a38deb7 Mon Sep 17 00:00:00 2001
+From: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
+Date: Mon, 29 Jun 2020 21:09:02 +0530
+Subject: [PATCH] arm64: dts: qcom: sm8250: Rename UART2 node to UART12
+
+The UART12 node has been mistakenly mentioned as UART2. Let's fix that
+for both SM8250 SoC and MTP board and also add pinctrl definition for
+it.
+
+Fixes: 60378f1a171e ("arm64: dts: qcom: sm8250: Add sm8250 dts file")
+Signed-off-by: Manivannan Sadhasivam <manivannan.sadhasivam@linaro.org>
+---
+ arch/arm64/boot/dts/qcom/sm8250-mtp.dts |  4 ++--
+ arch/arm64/boot/dts/qcom/sm8250.dtsi    | 11 ++++++++++-
+ 2 files changed, 12 insertions(+), 3 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/sm8250-mtp.dts b/arch/arm64/boot/dts/qcom/sm8250-mtp.dts
+index e9acda9f5b83..e844da89e688 100644
+--- a/arch/arm64/boot/dts/qcom/sm8250-mtp.dts
++++ b/arch/arm64/boot/dts/qcom/sm8250-mtp.dts
+@@ -13,7 +13,7 @@ / {
+ 	compatible = "qcom,sm8250-mtp";
+ 
+ 	aliases {
+-		serial0 = &uart2;
++		serial0 = &uart12;
+ 	};
+ 
+ 	chosen {
+@@ -359,7 +359,7 @@ &tlmm {
+ 	gpio-reserved-ranges = <28 4>, <40 4>;
+ };
+ 
+-&uart2 {
++&uart12 {
+ 	status = "okay";
+ };
+ 
+diff --git a/arch/arm64/boot/dts/qcom/sm8250.dtsi b/arch/arm64/boot/dts/qcom/sm8250.dtsi
+index 3ecc780a005d..ba8e8b8a90d2 100644
+--- a/arch/arm64/boot/dts/qcom/sm8250.dtsi
++++ b/arch/arm64/boot/dts/qcom/sm8250.dtsi
+@@ -865,11 +865,13 @@ spi12: spi@a90000 {
+ 				status = "disabled";
+ 			};
+ 
+-			uart2: serial@a90000 {
++			uart12: serial@a90000 {
+ 				compatible = "qcom,geni-debug-uart";
+ 				reg = <0x0 0x00a90000 0x0 0x4000>;
+ 				clock-names = "se";
+ 				clocks = <&gcc 113>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_uart12_default>;
+ 				interrupts = <GIC_SPI 357 IRQ_TYPE_LEVEL_HIGH>;
+ 				status = "disabled";
+ 			};
+@@ -1839,6 +1841,13 @@ config {
+ 					bias-disable;
+ 				};
+ 			};
++
++			qup_uart12_default: qup-uart12-default {
++				mux {
++					pins = "gpio34", "gpio35";
++					function = "qup12";
++				};
++			};
+ 		};
+ 
+ 		timer@17c20000 {
+-- 
+2.27.0
+

--- a/recipes-kernel/linux/linux-linaro-qcomlt-5.7/0001-arm64-dts-qcom-sm8250-add-I2C-and-SPI-nodes.patch
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-5.7/0001-arm64-dts-qcom-sm8250-add-I2C-and-SPI-nodes.patch
@@ -1,0 +1,1202 @@
+From ba21e7e0130be07dadf415e277524b6544680656 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Wed, 3 Jun 2020 18:42:42 +0300
+Subject: [PATCH] arm64: dts: qcom: sm8250: add I2C and SPI nodes
+
+Much like SDM845 each serial engine has 4 pins attached. Add all
+possible I2C and SPI nodes for all 20 serial engines.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+---
+ arch/arm64/boot/dts/qcom/sm8250.dtsi | 1147 ++++++++++++++++++++++++++
+ 1 file changed, 1147 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/qcom/sm8250.dtsi b/arch/arm64/boot/dts/qcom/sm8250.dtsi
+index 384839cb036c..37d3abeabf87 100644
+--- a/arch/arm64/boot/dts/qcom/sm8250.dtsi
++++ b/arch/arm64/boot/dts/qcom/sm8250.dtsi
+@@ -15,6 +15,49 @@ / {
+ 	#address-cells = <2>;
+ 	#size-cells = <2>;
+ 
++	aliases {
++		i2c0 = &i2c0;
++		i2c1 = &i2c1;
++		i2c2 = &i2c2;
++		i2c3 = &i2c3;
++		i2c4 = &i2c4;
++		i2c5 = &i2c5;
++		i2c6 = &i2c6;
++		i2c7 = &i2c7;
++		i2c8 = &i2c8;
++		i2c9 = &i2c9;
++		i2c10 = &i2c10;
++		i2c11 = &i2c11;
++		i2c12 = &i2c12;
++		i2c13 = &i2c13;
++		i2c14 = &i2c14;
++		i2c15 = &i2c15;
++		i2c16 = &i2c16;
++		i2c17 = &i2c17;
++		i2c18 = &i2c18;
++		i2c19 = &i2c19;
++		spi0 = &spi0;
++		spi1 = &spi1;
++		spi2 = &spi2;
++		spi3 = &spi3;
++		spi4 = &spi4;
++		spi5 = &spi5;
++		spi6 = &spi6;
++		spi7 = &spi7;
++		spi8 = &spi8;
++		spi9 = &spi9;
++		spi10 = &spi10;
++		spi11 = &spi11;
++		spi12 = &spi12;
++		spi13 = &spi13;
++		spi14 = &spi14;
++		spi15 = &spi15;
++		spi16 = &spi16;
++		spi17 = &spi17;
++		spi18 = &spi18;
++		spi19 = &spi19;
++	};
++
+ 	chosen { };
+ 
+ 	clocks {
+@@ -294,6 +337,394 @@ gcc: clock-controller@100000 {
+ 			clocks = <&rpmhcc RPMH_CXO_CLK>, <&sleep_clk>;
+ 		};
+ 
++		qupv3_id_2: geniqup@8c0000 {
++			compatible = "qcom,geni-se-qup";
++			reg = <0x0 0x008c0000 0x0 0x6000>;
++			clock-names = "m-ahb", "s-ahb";
++			clocks = <&gcc GCC_QUPV3_WRAP_2_M_AHB_CLK>,
++				 <&gcc GCC_QUPV3_WRAP_2_S_AHB_CLK>;
++			#address-cells = <2>;
++			#size-cells = <2>;
++			ranges;
++			status = "disabled";
++
++			i2c14: i2c@880000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00880000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP2_S0_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c14_default>;
++				interrupts = <GIC_SPI 373 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi14: spi@880000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00880000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP2_S0_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi14_default>;
++				interrupts = <GIC_SPI 373 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			i2c15: i2c@884000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00884000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP2_S1_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c15_default>;
++				interrupts = <GIC_SPI 583 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi15: spi@884000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00884000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP2_S1_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi15_default>;
++				interrupts = <GIC_SPI 583 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			i2c16: i2c@888000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00888000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP2_S2_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c16_default>;
++				interrupts = <GIC_SPI 584 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi16: spi@888000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00888000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP2_S2_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi16_default>;
++				interrupts = <GIC_SPI 584 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			i2c17: i2c@88c000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x0088c000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP2_S3_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c17_default>;
++				interrupts = <GIC_SPI 585 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi17: spi@88c000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x0088c000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP2_S3_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi17_default>;
++				interrupts = <GIC_SPI 585 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			i2c18: i2c@890000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00890000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP2_S4_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c18_default>;
++				interrupts = <GIC_SPI 586 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi18: spi@890000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00890000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP2_S4_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi18_default>;
++				interrupts = <GIC_SPI 586 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			i2c19: i2c@894000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00894000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP2_S5_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c19_default>;
++				interrupts = <GIC_SPI 587 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi19: spi@894000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00894000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP2_S5_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi19_default>;
++				interrupts = <GIC_SPI 587 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++		};
++
++		qupv3_id_0: geniqup@9c0000 {
++			compatible = "qcom,geni-se-qup";
++			reg = <0x0 0x009c0000 0x0 0x6000>;
++			clock-names = "m-ahb", "s-ahb";
++			clocks = <&gcc GCC_QUPV3_WRAP_0_M_AHB_CLK>,
++				 <&gcc GCC_QUPV3_WRAP_0_S_AHB_CLK>;
++			#address-cells = <2>;
++			#size-cells = <2>;
++			ranges;
++			status = "disabled";
++
++			i2c0: i2c@980000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00980000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP0_S0_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c0_default>;
++				interrupts = <GIC_SPI 601 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi0: spi@980000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00980000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP0_S0_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi0_default>;
++				interrupts = <GIC_SPI 601 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			i2c1: i2c@984000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00984000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP0_S1_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c1_default>;
++				interrupts = <GIC_SPI 602 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi1: spi@984000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00984000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP0_S1_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi1_default>;
++				interrupts = <GIC_SPI 602 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			i2c2: i2c@988000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00988000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP0_S2_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c2_default>;
++				interrupts = <GIC_SPI 603 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi2: spi@988000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00988000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP0_S2_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi2_default>;
++				interrupts = <GIC_SPI 603 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			i2c3: i2c@98c000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x0098c000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP0_S3_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c3_default>;
++				interrupts = <GIC_SPI 604 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi3: spi@98c000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x0098c000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP0_S3_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi3_default>;
++				interrupts = <GIC_SPI 604 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			i2c4: i2c@990000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00990000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP0_S4_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c4_default>;
++				interrupts = <GIC_SPI 605 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi4: spi@990000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00990000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP0_S4_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi4_default>;
++				interrupts = <GIC_SPI 605 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			i2c5: i2c@994000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00994000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP0_S5_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c5_default>;
++				interrupts = <GIC_SPI 606 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi5: spi@994000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00994000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP0_S5_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi5_default>;
++				interrupts = <GIC_SPI 606 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			i2c6: i2c@998000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00998000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP0_S6_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c6_default>;
++				interrupts = <GIC_SPI 607 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi6: spi@998000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00998000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP0_S6_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi6_default>;
++				interrupts = <GIC_SPI 607 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			i2c7: i2c@99c000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x0099c000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP0_S7_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c7_default>;
++				interrupts = <GIC_SPI 608 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi7: spi@99c000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x0099c000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP0_S7_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi7_default>;
++				interrupts = <GIC_SPI 608 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++		};
++
+ 		qupv3_id_1: geniqup@ac0000 {
+ 			compatible = "qcom,geni-se-qup";
+ 			reg = <0x0 0x00ac0000 0x0 0x6000>;
+@@ -304,6 +735,136 @@ qupv3_id_1: geniqup@ac0000 {
+ 			ranges;
+ 			status = "disabled";
+ 
++			i2c8: i2c@a80000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00a80000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP1_S0_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c8_default>;
++				interrupts = <GIC_SPI 353 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi8: spi@a80000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00a80000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP1_S0_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi8_default>;
++				interrupts = <GIC_SPI 353 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			i2c9: i2c@a84000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00a84000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP1_S1_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c9_default>;
++				interrupts = <GIC_SPI 354 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi9: spi@a84000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00a84000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP1_S1_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi9_default>;
++				interrupts = <GIC_SPI 354 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			i2c10: i2c@a88000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00a88000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP1_S2_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c10_default>;
++				interrupts = <GIC_SPI 355 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi10: spi@a88000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00a88000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP1_S2_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi10_default>;
++				interrupts = <GIC_SPI 355 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			i2c11: i2c@a8c000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00a8c000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP1_S3_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c11_default>;
++				interrupts = <GIC_SPI 356 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi11: spi@a8c000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00a8c000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP1_S3_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi11_default>;
++				interrupts = <GIC_SPI 356 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			i2c12: i2c@a90000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00a90000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP1_S4_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c12_default>;
++				interrupts = <GIC_SPI 357 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi12: spi@a90000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00a90000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP1_S4_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi12_default>;
++				interrupts = <GIC_SPI 357 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
+ 			uart2: serial@a90000 {
+ 				compatible = "qcom,geni-debug-uart";
+ 				reg = <0x0 0x00a90000 0x0 0x4000>;
+@@ -312,6 +873,32 @@ uart2: serial@a90000 {
+ 				interrupts = <GIC_SPI 357 IRQ_TYPE_LEVEL_HIGH>;
+ 				status = "disabled";
+ 			};
++
++			i2c13: i2c@a94000 {
++				compatible = "qcom,geni-i2c";
++				reg = <0 0x00a94000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP1_S5_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_i2c13_default>;
++				interrupts = <GIC_SPI 358 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
++
++			spi13: spi@a94000 {
++				compatible = "qcom,geni-spi";
++				reg = <0 0x00a94000 0 0x4000>;
++				clock-names = "se";
++				clocks = <&gcc GCC_QUPV3_WRAP1_S5_CLK>;
++				pinctrl-names = "default";
++				pinctrl-0 = <&qup_spi13_default>;
++				interrupts = <GIC_SPI 358 IRQ_TYPE_LEVEL_HIGH>;
++				#address-cells = <1>;
++				#size-cells = <0>;
++				status = "disabled";
++			};
+ 		};
+ 
+ 		ufs_mem_hc: ufshc@1d84000 {
+@@ -512,6 +1099,566 @@ tlmm: pinctrl@f100000 {
+ 			#interrupt-cells = <2>;
+ 			gpio-ranges = <&tlmm 0 0 180>;
+ 			wakeup-parent = <&pdc>;
++
++			qup_i2c0_default: qup-i2c0-default {
++				mux {
++					pins = "gpio28", "gpio29";
++					function = "qup0";
++				};
++
++				config {
++					pins = "gpio28", "gpio29";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c1_default: qup-i2c1-default {
++				pinmux {
++					pins = "gpio4", "gpio5";
++					function = "qup1";
++				};
++
++				config {
++					pins = "gpio4", "gpio5";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c2_default: qup-i2c2-default {
++				mux {
++					pins = "gpio115", "gpio116";
++					function = "qup2";
++				};
++
++				config {
++					pins = "gpio115", "gpio116";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c3_default: qup-i2c3-default {
++				mux {
++					pins = "gpio119", "gpio120";
++					function = "qup3";
++				};
++
++				config {
++					pins = "gpio119", "gpio120";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c4_default: qup-i2c4-default {
++				mux {
++					pins = "gpio8", "gpio9";
++					function = "qup4";
++				};
++
++				config {
++					pins = "gpio8", "gpio9";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c5_default: qup-i2c5-default {
++				mux {
++					pins = "gpio12", "gpio13";
++					function = "qup5";
++				};
++
++				config {
++					pins = "gpio12", "gpio13";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c6_default: qup-i2c6-default {
++				mux {
++					pins = "gpio16", "gpio17";
++					function = "qup6";
++				};
++
++				config {
++					pins = "gpio16", "gpio17";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c7_default: qup-i2c7-default {
++				mux {
++					pins = "gpio20", "gpio21";
++					function = "qup7";
++				};
++
++				config {
++					pins = "gpio20", "gpio21";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c8_default: qup-i2c8-default {
++				mux {
++					pins = "gpio24", "gpio25";
++					function = "qup8";
++				};
++
++				config {
++					pins = "gpio24", "gpio25";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c9_default: qup-i2c9-default {
++				mux {
++					pins = "gpio125", "gpio126";
++					function = "qup9";
++				};
++
++				config {
++					pins = "gpio125", "gpio126";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c10_default: qup-i2c10-default {
++				mux {
++					pins = "gpio129", "gpio130";
++					function = "qup10";
++				};
++
++				config {
++					pins = "gpio129", "gpio130";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c11_default: qup-i2c11-default {
++				mux {
++					pins = "gpio60", "gpio61";
++					function = "qup11";
++				};
++
++				config {
++					pins = "gpio60", "gpio61";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c12_default: qup-i2c12-default {
++				mux {
++					pins = "gpio32", "gpio33";
++					function = "qup12";
++				};
++
++				config {
++					pins = "gpio32", "gpio33";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c13_default: qup-i2c13-default {
++				mux {
++					pins = "gpio36", "gpio37";
++					function = "qup13";
++				};
++
++				config {
++					pins = "gpio36", "gpio37";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c14_default: qup-i2c14-default {
++				mux {
++					pins = "gpio40", "gpio41";
++					function = "qup14";
++				};
++
++				config {
++					pins = "gpio40", "gpio41";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c15_default: qup-i2c15-default {
++				mux {
++					pins = "gpio44", "gpio45";
++					function = "qup15";
++				};
++
++				config {
++					pins = "gpio44", "gpio45";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c16_default: qup-i2c16-default {
++				mux {
++					pins = "gpio48", "gpio49";
++					function = "qup16";
++				};
++
++				config {
++					pins = "gpio48", "gpio49";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c17_default: qup-i2c17-default {
++				mux {
++					pins = "gpio52", "gpio53";
++					function = "qup17";
++				};
++
++				config {
++					pins = "gpio52", "gpio53";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c18_default: qup-i2c18-default {
++				mux {
++					pins = "gpio56", "gpio57";
++					function = "qup18";
++				};
++
++				config {
++					pins = "gpio56", "gpio57";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_i2c19_default: qup-i2c19-default {
++				mux {
++					pins = "gpio0", "gpio1";
++					function = "qup19";
++				};
++
++				config {
++					pins = "gpio0", "gpio1";
++					drive-strength = <2>;
++					bias-disable;
++				};
++			};
++
++			qup_spi0_default: qup-spi0-default {
++				mux {
++					pins = "gpio28", "gpio29",
++					       "gpio30", "gpio31";
++					function = "qup0";
++				};
++
++				config {
++					pins = "gpio28", "gpio29",
++					       "gpio30", "gpio31";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi1_default: qup-spi1-default {
++				mux {
++					pins = "gpio4", "gpio5",
++					       "gpio6", "gpio7";
++					function = "qup1";
++				};
++
++				config {
++					pins = "gpio4", "gpio5",
++					       "gpio6", "gpio7";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi2_default: qup-spi2-default {
++				mux {
++					pins = "gpio115", "gpio116",
++					       "gpio117", "gpio118";
++					function = "qup2";
++				};
++
++				config {
++					pins = "gpio115", "gpio116",
++					       "gpio117", "gpio118";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi3_default: qup-spi3-default {
++				mux {
++					pins = "gpio119", "gpio120",
++					       "gpio121", "gpio122";
++					function = "qup3";
++				};
++
++				config {
++					pins = "gpio119", "gpio120",
++					       "gpio121", "gpio122";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi4_default: qup-spi4-default {
++				mux {
++					pins = "gpio8", "gpio9",
++					       "gpio10", "gpio11";
++					function = "qup4";
++				};
++
++				config {
++					pins = "gpio8", "gpio9",
++					       "gpio10", "gpio11";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi5_default: qup-spi5-default {
++				mux {
++					pins = "gpio12", "gpio13",
++					       "gpio14", "gpio15";
++					function = "qup5";
++				};
++
++				config {
++					pins = "gpio12", "gpio13",
++					       "gpio14", "gpio15";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi6_default: qup-spi6-default {
++				mux {
++					pins = "gpio16", "gpio17",
++					       "gpio18", "gpio19";
++					function = "qup6";
++				};
++
++				config {
++					pins = "gpio16", "gpio17",
++					       "gpio18", "gpio19";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi7_default: qup-spi7-default {
++				mux {
++					pins = "gpio20", "gpio21",
++					       "gpio22", "gpio23";
++					function = "qup7";
++				};
++
++				config {
++					pins = "gpio20", "gpio21",
++					       "gpio22", "gpio23";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi8_default: qup-spi8-default {
++				mux {
++					pins = "gpio24", "gpio25",
++					       "gpio26", "gpio27";
++					function = "qup8";
++				};
++
++				config {
++					pins = "gpio24", "gpio25",
++					       "gpio26", "gpio27";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi9_default: qup-spi9-default {
++				mux {
++					pins = "gpio125", "gpio126",
++					       "gpio127", "gpio128";
++					function = "qup9";
++				};
++
++				config {
++					pins = "gpio125", "gpio126",
++					       "gpio127", "gpio128";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi10_default: qup-spi10-default {
++				mux {
++					pins = "gpio129", "gpio130",
++					       "gpio131", "gpio132";
++					function = "qup10";
++				};
++
++				config {
++					pins = "gpio129", "gpio130",
++					       "gpio131", "gpio132";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi11_default: qup-spi11-default {
++				mux {
++					pins = "gpio60", "gpio61",
++					       "gpio62", "gpio63";
++					function = "qup11";
++				};
++
++				config {
++					pins = "gpio60", "gpio61",
++					       "gpio62", "gpio63";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi12_default: qup-spi12-default {
++				mux {
++					pins = "gpio32", "gpio33",
++					       "gpio34", "gpio35";
++					function = "qup12";
++				};
++
++				config {
++					pins = "gpio32", "gpio33",
++					       "gpio34", "gpio35";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi13_default: qup-spi13-default {
++				mux {
++					pins = "gpio36", "gpio37",
++					       "gpio38", "gpio39";
++					function = "qup13";
++				};
++
++				config {
++					pins = "gpio36", "gpio37",
++					       "gpio38", "gpio39";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi14_default: qup-spi14-default {
++				mux {
++					pins = "gpio40", "gpio41",
++					       "gpio42", "gpio43";
++					function = "qup14";
++				};
++
++				config {
++					pins = "gpio40", "gpio41",
++					       "gpio42", "gpio43";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi15_default: qup-spi15-default {
++				mux {
++					pins = "gpio44", "gpio45",
++					       "gpio46", "gpio47";
++					function = "qup15";
++				};
++
++				config {
++					pins = "gpio44", "gpio45",
++					       "gpio46", "gpio47";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi16_default: qup-spi16-default {
++				mux {
++					pins = "gpio48", "gpio49",
++					       "gpio50", "gpio51";
++					function = "qup16";
++				};
++
++				config {
++					pins = "gpio48", "gpio49",
++					       "gpio50", "gpio51";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi17_default: qup-spi17-default {
++				mux {
++					pins = "gpio52", "gpio53",
++					       "gpio54", "gpio55";
++					function = "qup17";
++				};
++
++				config {
++					pins = "gpio52", "gpio53",
++					       "gpio54", "gpio55";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi18_default: qup-spi18-default {
++				mux {
++					pins = "gpio56", "gpio57",
++					       "gpio58", "gpio59";
++					function = "qup18";
++				};
++
++				config {
++					pins = "gpio56", "gpio57",
++					       "gpio58", "gpio59";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
++
++			qup_spi19_default: qup-spi19-default {
++				mux {
++					pins = "gpio0", "gpio1",
++					       "gpio2", "gpio3";
++					function = "qup19";
++				};
++
++				config {
++					pins = "gpio0", "gpio1",
++					       "gpio2", "gpio3";
++					drive-strength = <6>;
++					bias-disable;
++				};
++			};
+ 		};
+ 
+ 		timer@17c20000 {
+-- 
+2.27.0
+

--- a/recipes-kernel/linux/linux-linaro-qcomlt-5.7/0001-arm64-dts-qcom-sm8250-change-spmi-node-label.patch
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-5.7/0001-arm64-dts-qcom-sm8250-change-spmi-node-label.patch
@@ -1,0 +1,29 @@
+From 6cdc941e6bf4df72844bd8b0fef2eff65d2c0726 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Thu, 4 Jun 2020 00:41:53 +0300
+Subject: [PATCH] arm64: dts: qcom: sm8250: change spmi node label
+
+PMIC dtsi files (pm8150*.dtsi) expect to have spmi_bus label, rather
+than just spmi. Rename spmi label accordingly.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+---
+ arch/arm64/boot/dts/qcom/sm8250.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/qcom/sm8250.dtsi b/arch/arm64/boot/dts/qcom/sm8250.dtsi
+index 1e2862bbfb11..9dd27aecdfda 100644
+--- a/arch/arm64/boot/dts/qcom/sm8250.dtsi
++++ b/arch/arm64/boot/dts/qcom/sm8250.dtsi
+@@ -991,7 +991,7 @@ pdc: interrupt-controller@b220000 {
+ 			interrupt-controller;
+ 		};
+ 
+-		spmi: qcom,spmi@c440000 {
++		spmi_bus: qcom,spmi@c440000 {
+ 			compatible = "qcom,spmi-pmic-arb";
+ 			reg = <0x0 0x0c440000 0x0 0x0001100>,
+ 			      <0x0 0x0c600000 0x0 0x2000000>,
+-- 
+2.27.0
+

--- a/recipes-kernel/linux/linux-linaro-qcomlt-5.7/qrb5165-rb5-enable.patch
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-5.7/qrb5165-rb5-enable.patch
@@ -1,0 +1,9 @@
+Index: git/arch/arm64/boot/dts/qcom/Makefile
+===================================================================
+--- git.orig/arch/arm64/boot/dts/qcom/Makefile
++++ git/arch/arm64/boot/dts/qcom/Makefile
+@@ -26,3 +26,4 @@ dtb-$(CONFIG_ARCH_QCOM)	+= sm8150-mtp.dt
+ dtb-$(CONFIG_ARCH_QCOM)	+= sm8250-mtp.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= qcs404-evb-1000.dtb
+ dtb-$(CONFIG_ARCH_QCOM)	+= qcs404-evb-4000.dtb
++dtb-$(CONFIG_ARCH_QCOM)	+= qrb5165-rb5.dtb

--- a/recipes-kernel/linux/linux-linaro-qcomlt-5.7/qrb5165-rb5.dts
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-5.7/qrb5165-rb5.dts
@@ -1,0 +1,760 @@
+// SPDX-License-Identifier: BSD-3-Clause
+/*
+ * Copyright (c) 2020, Linaro Ltd.
+ */
+
+/dts-v1/;
+
+#include <dt-bindings/gpio/gpio.h>
+#include <dt-bindings/regulator/qcom,rpmh-regulator.h>
+#include "sm8250.dtsi"
+#include "pm8150.dtsi"
+#include "pm8150b.dtsi"
+#include "pm8150l.dtsi"
+
+/ {
+	model = "Qualcomm Technologies, Inc. Robotics RB5";
+	compatible = "qcom,qrb5165-rb5", "qcom,sm8250";
+
+	aliases {
+		serial0 = &uart12;
+		sdhc2 = &sdhc_2;
+	};
+
+	chosen {
+		stdout-path = "serial0:115200n8";
+	};
+
+	dc12v: dc12v-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "DC12V";
+		regulator-min-microvolt = <12000000>;
+		regulator-max-microvolt = <12000000>;
+		regulator-always-on;
+	};
+
+	leds {
+		compatible = "gpio-leds";
+
+		user4 {
+			label = "green:user4";
+			gpios = <&pm8150_gpios 10 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "panic-indicator";
+			default-state = "off";
+		};
+
+		wlan {
+			label = "yellow:wlan";
+			gpios = <&pm8150_gpios 9 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "phy0tx";
+			default-state = "off";
+		};
+
+		bt {
+			label = "blue:bt";
+			gpios = <&pm8150_gpios 7 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "bluetooth-power";
+			default-state = "off";
+		};
+
+	};
+
+	vbat: vbat-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "VBAT";
+
+		vin-supply = <&dc12v>;
+		regulator-min-microvolt = <4200000>;
+		regulator-max-microvolt = <4200000>;
+		regulator-always-on;
+	};
+
+	vbat_som: vbat-som-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "VBAT_SOM";
+
+		vin-supply = <&dc12v>;
+		regulator-min-microvolt = <4200000>;
+		regulator-max-microvolt = <4200000>;
+		regulator-always-on;
+	};
+
+	vdc_3v3: vdc-3v3-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "VDC_3V3";
+		vin-supply = <&dc12v>;
+		regulator-min-microvolt = <3300000>;
+		regulator-max-microvolt = <3300000>;
+		regulator-always-on;
+	};
+
+	vdc_5v: vdc-5v-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "VDC_5V";
+
+		regulator-min-microvolt = <500000>;
+		regulator-max-microvolt = <500000>;
+		regulator-always-on;
+		vin-supply = <&vreg_l11c_3p3>;
+	};
+
+	vph_pwr: vph-pwr-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vph_pwr";
+		regulator-min-microvolt = <3700000>;
+		regulator-max-microvolt = <3700000>;
+	};
+
+	vreg_s4a_1p8: vreg-s4a-1p8 {
+		compatible = "regulator-fixed";
+		regulator-name = "vreg_s4a_1p8";
+
+		regulator-min-microvolt = <1800000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+		vin-supply = <&vph_pwr>;
+	};
+
+	vreg_s6c_0p88: smpc6-regulator {
+		compatible = "regulator-fixed";
+		regulator-name = "vreg_s6c_0p88";
+
+		regulator-min-microvolt = <752000>;
+		regulator-max-microvolt = <1800000>;
+		regulator-always-on;
+		vin-supply = <&vph_pwr>;
+	};
+};
+
+&apps_rsc {
+	pm8150-rpmh-regulators {
+		compatible = "qcom,pm8150-rpmh-regulators";
+		qcom,pmic-id = "a";
+
+		vdd-s1-supply = <&vph_pwr>;
+		vdd-s2-supply = <&vph_pwr>;
+		vdd-s3-supply = <&vph_pwr>;
+		vdd-s4-supply = <&vph_pwr>;
+		vdd-s5-supply = <&vph_pwr>;
+		vdd-s6-supply = <&vph_pwr>;
+		vdd-s7-supply = <&vph_pwr>;
+		vdd-s8-supply = <&vph_pwr>;
+		vdd-s9-supply = <&vph_pwr>;
+		vdd-s10-supply = <&vph_pwr>;
+		vdd-l2-l10-supply = <&vreg_bob>;
+		vdd-l3-l4-l5-l18-supply = <&vreg_s6a_0p95>;
+		vdd-l6-l9-supply = <&vreg_s8c_1p3>;
+		vdd-l7-l12-l14-l15-supply = <&vreg_s5a_1p9>;
+		vdd-l13-l16-l17-supply = <&vreg_bob>;
+
+		vreg_s5a_1p9: smps5 {
+			regulator-name = "vreg_s5a_1p9";
+			regulator-min-microvolt = <1904000>;
+			regulator-max-microvolt = <2000000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_s6a_0p95: smps6 {
+			regulator-name = "vreg_s6a_0p95";
+			regulator-min-microvolt = <920000>;
+			regulator-max-microvolt = <1128000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l2a_3p1: ldo2 {
+			regulator-name = "vreg_l2a_3p1";
+			regulator-min-microvolt = <3072000>;
+			regulator-max-microvolt = <3072000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l3a_0p9: ldo3 {
+			regulator-name = "vreg_l3a_0p9";
+			regulator-min-microvolt = <928000>;
+			regulator-max-microvolt = <932000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l5a_0p875: ldo5 {
+			regulator-name = "vreg_l5a_0p875";
+			regulator-min-microvolt = <880000>;
+			regulator-max-microvolt = <880000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l6a_1p2: ldo6 {
+			regulator-name = "vreg_l6a_1p2";
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <1200000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l7a_1p7: ldo7 {
+			regulator-name = "vreg_l7a_1p7";
+			regulator-min-microvolt = <1704000>;
+			regulator-max-microvolt = <1800000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l9a_1p2: ldo9 {
+			regulator-name = "vreg_l9a_1p2";
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <1200000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l10a_1p8: ldo10 {
+			regulator-name = "vreg_l10a_1p8";
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l12a_1p8: ldo12 {
+			regulator-name = "vreg_l12a_1p8";
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l13a_ts_3p0: ldo13 {
+			regulator-name = "vreg_l13a_ts_3p0";
+			regulator-min-microvolt = <3008000>;
+			regulator-max-microvolt = <3008000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l14a_1p8: ldo14 {
+			regulator-name = "vreg_l14a_1p8";
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1880000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l15a_11ad_io_1p8: ldo15 {
+			regulator-name = "vreg_l15a_11ad_io_1p8";
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l16a_2p7: ldo16 {
+			regulator-name = "vreg_l16a_2p7";
+			regulator-min-microvolt = <2704000>;
+			regulator-max-microvolt = <2960000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l17a_3p0: ldo17 {
+			regulator-name = "vreg_l17a_3p0";
+			regulator-min-microvolt = <2856000>;
+			regulator-max-microvolt = <3008000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l18a_0p92: ldo18 {
+			regulator-name = "vreg_l18a_0p92";
+			regulator-min-microvolt = <800000>;
+			regulator-max-microvolt = <912000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+	};
+
+	pm8150l-rpmh-regulators {
+		compatible = "qcom,pm8150l-rpmh-regulators";
+		qcom,pmic-id = "c";
+
+		vdd-s1-supply = <&vph_pwr>;
+		vdd-s2-supply = <&vph_pwr>;
+		vdd-s3-supply = <&vph_pwr>;
+		vdd-s4-supply = <&vph_pwr>;
+		vdd-s5-supply = <&vph_pwr>;
+		vdd-s6-supply = <&vph_pwr>;
+		vdd-s7-supply = <&vph_pwr>;
+		vdd-s8-supply = <&vph_pwr>;
+		vdd-l1-l8-supply = <&vreg_s4a_1p8>;
+		vdd-l2-l3-supply = <&vreg_s8c_1p3>;
+		vdd-l4-l5-l6-supply = <&vreg_bob>;
+		vdd-l7-l11-supply = <&vreg_bob>;
+		vdd-l9-l10-supply = <&vreg_bob>;
+		vdd-bob-supply = <&vph_pwr>;
+
+		vreg_bob: bob {
+			regulator-name = "vreg_bob";
+			regulator-min-microvolt = <3008000>;
+			regulator-max-microvolt = <4000000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_AUTO>;
+		};
+
+		vreg_s8c_1p3: smps8 {
+			regulator-name = "vreg_s8c_1p3";
+			regulator-min-microvolt = <1352000>;
+			regulator-max-microvolt = <1352000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l1c_1p8: ldo1 {
+			regulator-name = "vreg_l1c_1p8";
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l2c_1p2: ldo2 {
+			regulator-name = "vreg_l2c_1p2";
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <1200000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l3c_0p92: ldo3 {
+			regulator-name = "vreg_l3c_0p92";
+			regulator-min-microvolt = <800000>;
+			regulator-max-microvolt = <800000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l4c_1p7: ldo4 {
+			regulator-name = "vreg_l4c_1p7";
+			regulator-min-microvolt = <1704000>;
+			regulator-max-microvolt = <2928000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l5c_1p8: ldo5 {
+			regulator-name = "vreg_l5c_1p8";
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <2928000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l6c_2p9: ldo6 {
+			regulator-name = "vreg_l6c_2p9";
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <2960000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l7c_cam_vcm0_2p85: ldo7 {
+			regulator-name = "vreg_l7c_cam_vcm0_2p85";
+			regulator-min-microvolt = <2856000>;
+			regulator-max-microvolt = <3104000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l8c_1p8: ldo8 {
+			regulator-name = "vreg_l8c_1p8";
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l9c_2p9: ldo9 {
+			regulator-name = "vreg_l9c_2p9";
+			regulator-min-microvolt = <2704000>;
+			regulator-max-microvolt = <2960000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l10c_3p0: ldo10 {
+			regulator-name = "vreg_l10c_3p0";
+			regulator-min-microvolt = <3000000>;
+			regulator-max-microvolt = <3000000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l11c_3p3: ldo11 {
+			regulator-name = "vreg_l11c_3p3";
+			regulator-min-microvolt = <3296000>;
+			regulator-max-microvolt = <3296000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+			regulator-always-on;
+		};
+	};
+
+	pm8009-rpmh-regulators {
+		compatible = "qcom,pm8009-rpmh-regulators";
+		qcom,pmic-id = "f";
+
+		vdd-s1-supply = <&vph_pwr>;
+		vdd-s2-supply = <&vph_pwr>;
+		vdd-l2-supply = <&vreg_s8c_1p3>;
+		vdd-l5-l6-supply = <&vreg_bob>;
+		vdd-l7-supply = <&vreg_s4a_1p8>;
+
+		vreg_l1f_cam_dvdd1_1p1: ldo1 {
+			regulator-name = "vreg_l1f_cam_dvdd1_1p1";
+			regulator-min-microvolt = <1104000>;
+			regulator-max-microvolt = <1104000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l2f_cam_dvdd0_1p2: ldo2 {
+			regulator-name = "vreg_l2f_cam_dvdd0_1p2";
+			regulator-min-microvolt = <1200000>;
+			regulator-max-microvolt = <1200000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l3f_cam_dvdd2_1p05: ldo3 {
+			regulator-name = "vreg_l3f_cam_dvdd2_1p05";
+			regulator-min-microvolt = <1056000>;
+			regulator-max-microvolt = <1056000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l5f_cam_avdd0_2p85: ldo5 {
+			regulator-name = "vreg_l5f_cam_avdd0_2p85";
+			regulator-min-microvolt = <2800000>;
+			regulator-max-microvolt = <2800000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l6f_cam_avdd1_2p85: ldo6 {
+			regulator-name = "vreg_l6f_cam_avdd1_2p85";
+			regulator-min-microvolt = <2856000>;
+			regulator-max-microvolt = <2856000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+
+		vreg_l7f_1p8: ldo7 {
+			regulator-name = "vreg_l7f_1p8";
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			regulator-initial-mode = <RPMH_REGULATOR_MODE_HPM>;
+		};
+	};
+};
+
+/* LS-I2C0 */
+&i2c4 {
+	status = "okay";
+};
+
+&i2c5 {
+	status = "okay";
+};
+
+/* LS-I2C1 */
+&i2c15 {
+	status = "okay";
+};
+
+&pm8150_gpios {
+	gpio-reserved-ranges = <1 1>, <3 2>, <7 1>;
+	gpio-line-names =
+		"NC",
+		"OPTION2",
+		"PM_GPIO-F",
+		"PM_SLP_CLK_IN",
+		"OPTION1",
+		"VOL_UP_N",
+		"PM8250_GPIO7", /* Blue LED */
+		"SP_ARI_PWR_ALARM",
+		"GPIO_9_P", /* Yellow LED */
+		"GPIO_10_P"; /* Green LED */
+};
+
+&pm8150b_gpios {
+	gpio-line-names =
+		"NC",
+		"NC",
+		"NC",
+		"NC",
+		"HAP_BOOST_EN", /* SOM */
+		"SMB_STAT", /* SOM */
+		"NC",
+		"NC",
+		"SDM_FORCE_USB_BOOT",
+		"NC",
+		"NC",
+		"NC";
+};
+
+&pm8150l_gpios {
+	gpio-line-names =
+		"NC",
+		"PM3003A_EN",
+		"NC",
+		"NC",
+		"PM_GPIO5", /* HDMI RST_N */
+		"PM_GPIO-A", /* PWM */
+		"PM_GPIO7",
+		"NC",
+		"NC",
+		"PM_GPIO-B",
+		"NC",
+		"PM3003A_MODE";
+};
+
+&qupv3_id_0 {
+	status = "okay";
+};
+
+&qupv3_id_1 {
+	status = "okay";
+};
+
+&qupv3_id_2 {
+	status = "okay";
+};
+
+/* CAN */
+&spi0 {
+	status = "okay";
+};
+
+&tlmm {
+	gpio-reserved-ranges = <40 4>;
+	gpio-line-names =
+		"GPIO-MM",
+		"GPIO-NN",
+		"GPIO-OO",
+		"GPIO-PP",
+		"GPIO-A",
+		"GPIO-C",
+		"GPIO-E",
+		"GPIO-D",
+		"I2C0-SDA",
+		"I2C0-SCL",
+		"GPIO-TT", /* GPIO_10 */
+		"NC",
+		"GPIO_12_I2C_SDA",
+		"GPIO_13_I2C_SCL",
+		"GPIO-X",
+		"GPIO_15_RGMII_INT",
+		"HST_BT_UART_CTS",
+		"HST_BT_UART_RFR",
+		"HST_BT_UART_TX",
+		"HST_BT_UART_RX",
+		"HST_WLAN_EN", /* GPIO_20 */
+		"HST_BT_EN",
+		"GPIO-AAA",
+		"GPIO-BBB",
+		"GPIO-CCC",
+		"GPIO-Z",
+		"GPIO-DDD",
+		"GPIO-BB",
+		"GPIO_28_CAN_SPI_MISO",
+		"GPIO_29_CAN_SPI_MOSI",
+		"GPIO_30_CAN_SPI_CLK", /* GPIO_30 */
+		"GPIO_31_CAN_SPI_CS",
+		"GPIO-UU",
+		"NC",
+		"UART1_TXD_SOM",
+		"UART1_RXD_SOM",
+		"UART0_CTS",
+		"UART0_RTS",
+		"UART0_TXD",
+		"UART0_RXD",
+		"SPI1_MISO", /* GPIO_40 */
+		"SPI1_MOSI",
+		"SPI1_CLK",
+		"SPI1_CS",
+		"I2C1_SDA",
+		"I2C1_SCL",
+		"GPIO-F",
+		"GPIO-JJ",
+		"Board_ID1",
+		"Board_ID2",
+		"NC", /* GPIO_50 */
+		"NC",
+		"SPI0_MISO",
+		"SPI0_MOSI",
+		"SPI0_SCLK",
+		"SPI0_CS",
+		"GPIO-QQ",
+		"GPIO-RR",
+		"USB2LAN_RESET",
+		"USB2LAN_EXTWAKE",
+		"NC", /* GPIO_60 */
+		"NC",
+		"NC",
+		"LT9611_INT",
+		"GPIO-AA",
+		"USB_CC_DIR",
+		"GPIO-G",
+		"GPIO-LL",
+		"USB_DP_HPD_1P8",
+		"NC",
+		"NC", /* GPIO_70 */
+		"SD_CMD",
+		"SD_DAT3",
+		"SD_SCLK",
+		"SD_DAT2",
+		"SD_DAT1",
+		"SD_DAT0", /* BOOT_CFG3 */
+		"SD_UFS_CARD_DET_N",
+		"GPIO-II",
+		"PCIE0_RST_N",
+		"PCIE0_CLK_REQ_N", /* GPIO_80 */
+		"PCIE0_WAKE_N",
+		"GPIO-CC",
+		"GPIO-DD",
+		"GPIO-EE",
+		"GPIO-FF",
+		"GPIO-GG",
+		"GPIO-HH",
+		"GPIO-VV",
+		"GPIO-WW",
+		"NC", /* GPIO_90 */
+		"NC",
+		"GPIO-K",
+		"GPIO-I",
+		"CSI0_MCLK",
+		"CSI1_MCLK",
+		"CSI2_MCLK",
+		"CSI3_MCLK",
+		"GPIO-AA", /* CSI4_MCLK */
+		"GPIO-BB", /* CSI5_MCLK */
+		"GPIO-KK", /* GPIO_100 */
+		"CCI_I2C_SDA0",
+		"CCI_I2C_SCL0",
+		"CCI_I2C_SDA1",
+		"CCI_I2C_SCL1",
+		"CCI_I2C_SDA2",
+		"CCI_I2C_SCL2",
+		"CCI_I2C_SDA3",
+		"CCI_I2C_SCL3",
+		"GPIO-L",
+		"NC", /* GPIO_110 */
+		"NC",
+		"ACCEL_INT",
+		"GYRO_INT",
+		"GPIO-J",
+		"GPIO-YY",
+		"GPIO-H",
+		"GPIO-ZZ",
+		"NC",
+		"NC",
+		"NC", /* GPIO_120 */
+		"NC",
+		"MAG_INT",
+		"MAG_DRDY_INT",
+		"HST_SW_CTRL",
+		"GPIO-M",
+		"GPIO-N",
+		"GPIO-O",
+		"GPIO-P",
+		"PS_INT",
+		"WSA1_EN", /* GPIO_130 */
+		"USB_HUB_RESET",
+		"SDM_FORCE_USB_BOOT",
+		"I2S1_CLK_HDMI",
+		"I2S1_DATA0_HDMI",
+		"I2S1_WS_HDMI",
+		"GPIO-B",
+		"GPIO_137", /* To LT9611_I2S_MCLK_3V3 */
+		"PCM_CLK",
+		"PCM_DI",
+		"PCM_DO", /* GPIO_140 */
+		"PCM_FS",
+		"HST_SLIM_CLK",
+		"HST_SLIM_DATA",
+		"GPIO-U",
+		"GPIO-Y",
+		"GPIO-R",
+		"GPIO-Q",
+		"GPIO-S",
+		"GPIO-T",
+		"GPIO-V", /* GPIO_150 */
+		"GPIO-W",
+		"DMIC_CLK1",
+		"DMIC_DATA1",
+		"DMIC_CLK2",
+		"DMIC_DATA2",
+		"WSA_SWR_CLK",
+		"WSA_SWR_DATA",
+		"DMIC_CLK3",
+		"DMIC_DATA3",
+		"I2C4_SDA", /* GPIO_160 */
+		"I2C4_SCL",
+		"SPI3_CS1",
+		"SPI3_CS2",
+		"SPI2_MISO_LS3",
+		"SPI2_MOSI_LS3",
+		"SPI2_CLK_LS3",
+		"SPI2_ACCEL_CS_LS3",
+		"SPI2_CS1",
+		"NC",
+		"GPIO-SS", /* GPIO_170 */
+		"GPIO-XX",
+		"SPI3_MISO",
+		"SPI3_MOSI",
+		"SPI3_CLK",
+		"SPI3_CS",
+		"HST_BLE_SNS_UART_TX",
+		"HST_BLE_SNS_UART_RX",
+		"HST_WLAN_UART_TX",
+		"HST_WLAN_UART_RX";
+};
+
+&uart12 {
+	status = "okay";
+};
+
+&ufs_mem_hc {
+	status = "okay";
+
+	vcc-supply = <&vreg_l17a_3p0>;
+	vcc-max-microamp = <800000>;
+	vccq-supply = <&vreg_l6a_1p2>;
+	vccq-max-microamp = <800000>;
+	vccq2-supply = <&vreg_s4a_1p8>;
+	vccq2-max-microamp = <800000>;
+};
+
+&ufs_mem_phy {
+	status = "okay";
+
+	vdda-phy-supply = <&vreg_l5a_0p875>;
+	vdda-max-microamp = <89900>;
+	vdda-pll-supply = <&vreg_l9a_1p2>;
+	vdda-pll-max-microamp = <18800>;
+};
+
+&usb_1 {
+	status = "okay";
+};
+
+&usb_1_dwc3 {
+	dr_mode = "peripheral";
+};
+
+&usb_1_hsphy {
+	status = "okay";
+
+	vdda-pll-supply = <&vreg_l5a_0p875>;
+	vdda33-supply = <&vreg_l2a_3p1>;
+	vdda18-supply = <&vreg_l12a_1p8>;
+};
+
+&usb_1_qmpphy {
+	status = "okay";
+
+	vdda-phy-supply = <&vreg_l9a_1p2>;
+	vdda-pll-supply = <&vreg_l18a_0p92>;
+};
+
+&usb_2 {
+	status = "okay";
+};
+
+&usb_2_dwc3 {
+	dr_mode = "host";
+};
+
+&usb_2_hsphy {
+	status = "okay";
+
+	vdda-pll-supply = <&vreg_l5a_0p875>;
+	vdda33-supply = <&vreg_l2a_3p1>;
+	vdda18-supply = <&vreg_l12a_1p8>;
+};
+
+&usb_2_qmpphy {
+	status = "okay";
+
+	vdda-phy-supply = <&vreg_l9a_1p2>;
+	vdda-pll-supply = <&vreg_l18a_0p92>;
+};

--- a/recipes-kernel/linux/linux-linaro-qcomlt-dev.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-dev.bb
@@ -1,0 +1,24 @@
+# Copyright (C) 2014-2020 Linaro
+# Released under the MIT license (see COPYING.MIT for the terms)
+#
+# This recipe is disabled by default.
+# To enable it add the following line to conf/local.conf:
+# PREFERRED_PROVIDER_virtual/kernel = "linux-linaro-qcomlt-dev"
+
+DESCRIPTION = "Linaro Qualcomm Landing team Integration Kernel ${PV}"
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+require recipes-kernel/linux/linux-linaro-qcom.inc
+require recipes-kernel/linux/linux-qcom-bootimg.inc
+
+SRCBRANCH ?= "integration-linux-qcomlt"
+SRCREV ?= "${AUTOREV}"
+
+LINUX_VERSION = "5.8-rc+"
+PV = "${LINUX_VERSION}+git${SRCPV}"
+
+# Wifi firmware has a recognizable arch :( 
+ERROR_QA_remove = "arch"
+
+# Disable by default
+DEFAULT_PREFERENCE = "-1"

--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.7.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.7.bb
@@ -9,6 +9,16 @@ inherit python3native
 require recipes-kernel/linux/linux-linaro-qcom.inc
 require recipes-kernel/linux/linux-qcom-bootimg.inc
 
+SRC_URI_append_qrb5165-rb5 = " \
+    file://qrb5165-rb5.dts;subdir=git/arch/arm64/boot/dts/qcom \
+    file://qrb5165-rb5-enable.patch \
+    file://0001-arm64-dts-qcom-sm8250-change-spmi-node-label.patch \
+    file://0001-arm64-dts-qcom-sm8250-add-I2C-and-SPI-nodes.patch \
+    file://0001-arm64-dts-qcom-sm8250-Add-USB-and-PHY-device-nodes.patch \
+    file://0001-arm64-dts-qcom-sm8250-Rename-UART2-node-to-UART12.patch \
+    file://0001-arm64-dts-qcom-sm8250-Add-support-for-SDC2.patch \
+"
+
 LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "release/qcomlt-5.7"
 SRCREV ?= "37b31489130dbeb8fa89dc99e8ff99c80fa264e0"


### PR DESCRIPTION
Add initial support for Qualcomm RB5 robotics platform:
 - machine config,
 - dts tree support for 5.7 kernel,
 - new linux-linaro-qcomlt-dev recipe tracking latest integration tree.