### PR TITLE
recipes-kernel: Linux 5.7 bump to 5.7.7 (21bb88052948)

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.7.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.7.bb
@@ -21,7 +21,7 @@ SRC_URI_append_qrb5165-rb5 = " \
 
 LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "release/qcomlt-5.7"
-SRCREV ?= "37b31489130dbeb8fa89dc99e8ff99c80fa264e0"
+SRCREV ?= "21bb88052948b35bdce926f301f2ba7970040812"
 
 COMPATIBLE_MACHINE = "(apq8016|apq8096|sdm845|sm8250)"
 


### PR DESCRIPTION
Changes,

21bb88052948 venus: firmware: Set virtual address ranges
2d8435ad822f firmware: qcom_scm: Add memory protect virtual address ranges
4130227f0f7e Merge tag 'v5.7.7' into release/qcomlt-5.7
fb6c79052380 Linux 5.7.7

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>