### PR TITLE
Add kernel-{image,devicetree} to dragonboard-410c MACHINE_ESSENTIAL_E…

### DIFF
--- a/conf/machine/dragonboard-410c.conf
+++ b/conf/machine/dragonboard-410c.conf
@@ -13,6 +13,8 @@ KERNEL_DEVICETREE ?= "qcom/apq8016-sbc.dtb"
 SERIAL_CONSOLE ?= "115200 ttyMSM0"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    kernel-image \
+    kernel-devicetree \
     kernel-modules \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a3xx mesa-driver-msm', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluez5', 'bluez5-noinst-tools', '', d)} \


### PR DESCRIPTION
…XTRA_RRECOMMENDS

For enable u-boot and have Kernel image and devicetree installed at
/boot.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>