### PR TITLE
recipes-kernel: Linux 5.7 bump to 5.7.19 (4af49ea41ecf1)

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.7.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.7.bb
@@ -21,7 +21,7 @@ SRC_URI_append_qrb5165-rb5 = " \
 
 LOCALVERSION ?= "-linaro-lt-qcom"
 SRCBRANCH ?= "release/qcomlt-5.7"
-SRCREV ?= "21bb88052948b35bdce926f301f2ba7970040812"
+SRCREV ?= "4af49ea41ecf17e5e6243f3ac81dfc2f84d8a3a1"
 
 COMPATIBLE_MACHINE = "(apq8016|apq8096|sdm845|sm8250)"
 


### PR DESCRIPTION
Summary,

* Point update to 5.7.19.
* Fixes on venus encoder and boot on DB820c (msm8996).

Changes,

4af49ea41ecf1 Merge tag 'v5.7.19' into release/qcomlt-5.7
...
0251e67cac68e media: venus: Fix reported frame intervals
565814f2abdb9 Merge tag 'v5.7.12' into release/qcomlt-5.7
...
9f6b67115e558 Merge tag 'v5.7.11' into release/qcomlt-5.7
...
2800aaa3b8bfb arm64: dts: qcom: msm8996: Reduce vdd_apc voltage
f0d61fa89bed5 Revert "arch: arm64: dts: msm8996: Change opp table compatible string"

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>