### PR TITLE
Use venus 5.2 from linux-firmware for DB845c and replace dhcp-client with dhcpcd

### DIFF
--- a/conf/machine/dragonboard-845c.conf
+++ b/conf/machine/dragonboard-845c.conf
@@ -19,6 +19,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     linux-firmware-qcom-sdm845-audio \
     linux-firmware-qcom-sdm845-compute \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 mesa-driver-msm', '', d)} \
+    linux-firmware-qcom-venus-5.2 \
 "
 
 # /dev/sda1 is 'rootfs' partition after installing the latest bootloader package from linaro

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
@@ -27,14 +27,12 @@ do_compile() {
 
 do_install() {
     install -d ${D}${nonarch_base_libdir}/firmware/
-    install -d ${D}${nonarch_base_libdir}/firmware/qcom/venus-5.2/
     install -d ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
 
     install -m 0444 ./17-USB3-201-202-FW/K2026090.mem ${D}${nonarch_base_libdir}/firmware/
     install -m 0444 ./18-adreno-fw/a630_zap*.* ${D}${nonarch_base_libdir}/firmware/qcom/
     install -m 0444 ./20-adsp_split/firmware/adsp*.* ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
     install -m 0444 ./21-cdsp_split/firmware/cdsp*.* ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
-    install -m 0444 ./33-venus_split/venus.* ${D}${nonarch_base_libdir}/firmware/qcom/venus-5.2/
 
     install -d ${D}${nonarch_base_libdir}/firmware/ath10k/WCN3990/hw1.0/
     install -m 0444 ./board-2.bin ${D}${nonarch_base_libdir}/firmware/ath10k/WCN3990/hw1.0/
@@ -45,10 +43,6 @@ do_install() {
 
 FILES_${PN} += "${nonarch_base_libdir}/firmware/*"
 INSANE_SKIP_${PN} += "arch"
-
-RPROVIDES_${PN} += "linux-firmware-qcom-venus-5.2"
-RREPLACES_${PN} += "linux-firmware-qcom-venus-5.2"
-RCONFLICTS_${PN} += "linux-firmware-qcom-venus-5.2"
 
 RPROVIDES_${PN} += "linux-firmware-qcom-license"
 RREPLACES_${PN} += "linux-firmware-qcom-license"

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,7 +1,0 @@
-
-do_install_append() {
-        rm -rf ${D}${nonarch_base_libdir}/firmware/qcom/venus-5.2
-        rm -rf ${D}${nonarch_base_libdir}/firmware/qcom/venus-5.4
-}
-
-

--- a/recipes-test/images/initramfs-test-image.bb
+++ b/recipes-test/images/initramfs-test-image.bb
@@ -5,7 +5,7 @@ PACKAGE_INSTALL = " \
     bluez5 \
     busybox \
     base-passwd \
-    dhcp-client \
+    dhcpcd \
     diag \
     e2fsprogs \
     e2fsprogs-e2fsck \


### PR DESCRIPTION
A fix was add on mainline to support linux-firmware binary,

https://git.linaro.org/landing-teams/working/qualcomm/kernel.git/commit/?h=release/qcomlt-5.7&id=21bb88052948b35bdce926f301f2ba7970040812

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>