### PR TITLE
qrb5165-rb5: correct rootfs (userdata) partition

### DIFF
--- a/conf/machine/qrb5165-rb5.conf
+++ b/conf/machine/qrb5165-rb5.conf
@@ -19,8 +19,8 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 "
 # linux-firmware-qcom-adreno-a650 
 
-# /dev/sda15 is 'userdata' partition, so wipe it and use for our build
-QCOM_BOOTIMG_ROOTFS ?= "sda15"
+# /dev/sda6 is 'userdata' partition, so wipe it and use for our build
+QCOM_BOOTIMG_ROOTFS ?= "sda6"
 
 # UFS partitions setup with 4096 logical sector size
 EXTRA_IMAGECMD_ext4 += " -b 4096 "


### PR DESCRIPTION
QRB5165 RB5 machine config lists sda15 as rootfs, which is C&P from
SM8250-MTP. Use sda6 as rootfs (which is proper userdata on RB5).

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>