### PR TITLE
recipes-bsp/firmware: Compatible machine and License install

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-dragonboard410c-bootloader-sdcard_17.09.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard410c-bootloader-sdcard_17.09.bb
@@ -9,7 +9,6 @@ SRC_URI = "https://releases.linaro.org/96boards/dragonboard410c/linaro/rescue/17
 SRC_URI[md5sum] = "e15da2a623442d66587aea506599fb69"
 SRC_URI[sha256sum] = "9885f915ebd4986432340cf1d03b8fd2bfdd97ad6a4a7466200fddbe41cdcf5c"
 
-COMPATIBLE_MACHINE = "(dragonboard-410c)"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 S = "${WORKDIR}"

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard410c_1034.2.1.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard410c_1034.2.1.bb
@@ -9,7 +9,6 @@ SRC_URI[sha256sum] = "46953b974c5c58c7ca66db414437c0268b033ac9d28127e98d9c4e1a49
 
 DEPENDS += "mtools-native"
 
-COMPATIBLE_MACHINE = "(dragonboard-410c)"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 S = "${WORKDIR}/linux-board-support-package-r${PV}"
@@ -31,7 +30,7 @@ do_install() {
     ::image/modem.* ::image/mba.mbn ::image/wcnss.* ${D}${nonarch_base_libdir}/firmware/qcom/msm8916
 
     install -d ${D}${sysconfdir}/
-    install -m 0644 LICENSE ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE
+    install -m 0644 LICENSE ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE-${PN}
 }
 
 FILES_${PN} += "/boot/modem_fsg"
@@ -39,7 +38,3 @@ FILES_${PN} += "${nonarch_base_libdir}/firmware/wlan/*"
 FILES_${PN} += "${nonarch_base_libdir}/firmware/qcom/msm8916/*"
 
 INSANE_SKIP_${PN} += "arch"
-
-RPROVIDES_${PN} += "linux-firmware-qcom-license"
-RREPLACES_${PN} += "linux-firmware-qcom-license"
-RCONFLICTS_${PN} += "linux-firmware-qcom-license"

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard820c_01700.1.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard820c_01700.1.bb
@@ -7,7 +7,6 @@ SRC_URI = "https://releases.linaro.org/96boards/dragonboard820c/qualcomm/firmwar
 SRC_URI[md5sum] = "587138c5e677342db9a88d5c8747ec6c"
 SRC_URI[sha256sum] = "6ee9c461b2b5dd2d3bd705bb5ea3f44b319ecb909b2772f305ce12439e089cd9"
 
-COMPATIBLE_MACHINE = "(dragonboard-820c)"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 S = "${WORKDIR}/linux-board-support-package-r${PV}"
@@ -23,12 +22,8 @@ do_install() {
     install -m 0444 ./proprietary-linux/adsp*.* ${D}${nonarch_base_libdir}/firmware/qcom/msm8996/
 
     install -d ${D}${sysconfdir}/
-    install -m 0644 LICENSE ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE
+    install -m 0644 LICENSE ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE-${PN}
 }
 
 FILES_${PN} += "${nonarch_base_libdir}/firmware/*"
 INSANE_SKIP_${PN} += "arch"
-
-RPROVIDES_${PN} += "linux-firmware-qcom-license"
-RREPLACES_${PN} += "linux-firmware-qcom-license"
-RCONFLICTS_${PN} += "linux-firmware-qcom-license"

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
@@ -10,7 +10,6 @@ SRC_URI[md5sum] = "ad69855a1275547b16d94a1b5405ac62"
 SRC_URI[sha256sum] = "4289d2f2a7124b104d0274879e702aae9b1e50c42eec3747f8584c6744ef65e3"
 SRCREV = "0c01a2abc3e9855b71f0fbea2c335011104d9ec0"
 
-COMPATIBLE_MACHINE = "(dragonboard-845c)"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 DEPENDS += "bash-native"
 inherit python3native
@@ -38,12 +37,8 @@ do_install() {
     install -m 0444 ./board-2.bin ${D}${nonarch_base_libdir}/firmware/ath10k/WCN3990/hw1.0/
 
     install -d ${D}${sysconfdir}/
-    install -m 0644 LICENSE.qcom.txt ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE
+    install -m 0644 LICENSE.qcom.txt ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE-${PN}
 }
 
 FILES_${PN} += "${nonarch_base_libdir}/firmware/*"
 INSANE_SKIP_${PN} += "arch"
-
-RPROVIDES_${PN} += "linux-firmware-qcom-license"
-RREPLACES_${PN} += "linux-firmware-qcom-license"
-RCONFLICTS_${PN} += "linux-firmware-qcom-license"

--- a/recipes-bsp/firmware/firmware-qcom-rb5_1.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-rb5_1.0.bb
@@ -18,7 +18,6 @@ ADRENO_ARCHIVE = "adreno_1.0_qrb5165_rb5.tar.gz"
 SRC_URI_NHLOS = "${NHLOS_URI}${NHLOS_ARCHIVE}"
 SRC_URI_ADRENO = "${ADRENO_URI}${ADRENO_ARCHIVE};unpack=0"
 
-COMPATIBLE_MACHINE = "(sm8250)"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 # do_unpack is written in Python, so let's use do_compile here

--- a/recipes-bsp/firmware/firmware-qcom-sd-600eval_1.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-sd-600eval_1.0.bb
@@ -7,7 +7,6 @@ SRC_URI = "https://eragon.einfochips.com/pub/media/datasheet/SD_600eval-linux_pr
 SRC_URI[md5sum] = "0903e9f656d3cea005ecc8e26f1243b2"
 SRC_URI[sha256sum] = "fdffcb2cedc0d0215ee3dec95ce3683a780d9280960d27200379fbe1b21af979"
 
-COMPATIBLE_MACHINE = "(sd-600eval|dragonboard-600c)"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 S = "${WORKDIR}/SD_600eval-linux_proprietary_firmware-v${PV}"


### PR DESCRIPTION
- Remove COMPATIBLE_MACHINE to allow be installed in any machine.

- Remove conflicts with linux-firmware-qcom-license:
  When try to install together this tree packages fails due to each of
  them provide license so use linux-firmware one since we are using
  linux-firmware when available.

- Install each license with ${PN} suffix to avoid install
  conflicts.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>