### PR TITLE
firmware-qcom-sd-600eval: Skip checking for already stripped binaries

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-sd-600eval_1.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-sd-600eval_1.0.bb
@@ -24,4 +24,4 @@ do_install() {
 }
 
 FILES_${PN} += "${nonarch_base_libdir}/firmware/*"
-INSANE_SKIP_${PN} += "arch"
+INSANE_SKIP_${PN} += "arch already-stripped"


### PR DESCRIPTION
Fixes
ERROR: QA Issue: File '/lib/firmware/dsps.b00' from firmware-qcom-sd-600eval was already stripped, this will prevent future debugging! [already-stripped]
ERROR: QA Issue: File '/lib/firmware/dsps.mdt' from firmware-qcom-sd-600eval was already stripped, this will prevent future debugging! [already-stripped]
ERROR: QA Issue: File '/lib/firmware/gss.b00' from firmware-qcom-sd-600eval was already stripped, this will prevent future debugging! [already-stripped]
ERROR: QA Issue: File '/lib/firmware/gss.mdt' from firmware-qcom-sd-600eval was already stripped, this will prevent future debugging! [already-stripped]
ERROR: QA Issue: File '/lib/firmware/mobicore.b00' from firmware-qcom-sd-600eval was already stripped, this will prevent future debugging! [already-stripped]

Signed-off-by: Khem Raj <raj.khem@gmail.com>