### PR TITLE
firmware-qcom-sd-600eval: Replace cp -a with proper options

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-sd-600eval_1.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-sd-600eval_1.0.bb
@@ -17,7 +17,7 @@ do_compile() {
 
 do_install() {
     install -d  ${D}${nonarch_base_libdir}/firmware/
-    cp -a * ${D}${nonarch_base_libdir}/firmware/
+    cp -R --no-dereference --preserve=mode,links * ${D}${nonarch_base_libdir}/firmware/
 
     install -d ${D}${sysconfdir}/
     install -m 0644 license.txt ${D}${sysconfdir}/


### PR DESCRIPTION
Fixes errors like
firmware-qcom-sd-600eval: /lib/firmware/a225_pfp.fw is owned by uid 1000, which is the same as the user running bitbake. This may be due to host contamination

Signed-off-by: Khem Raj <raj.khem@gmail.com>