### PR TITLE
qrb5165-rb5: Correct userdata partition on RB5

### DIFF
--- a/conf/machine/qrb5165-rb5.conf
+++ b/conf/machine/qrb5165-rb5.conf
@@ -19,8 +19,8 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 "
 # linux-firmware-qcom-adreno-a650 
 
-# /dev/sda6 is 'userdata' partition, so wipe it and use for our build
-QCOM_BOOTIMG_ROOTFS ?= "sda6"
+# /dev/sda8 is 'userdata' partition, so wipe it and use for our build
+QCOM_BOOTIMG_ROOTFS ?= "sda8"
 
 # UFS partitions setup with 4096 logical sector size
 EXTRA_IMAGECMD_ext4 += " -b 4096 "


### PR DESCRIPTION
Now let's get it right. Userdata partition on RB5 is sda8, not sda6.
sda6 is system_a:

   1               6               7   8.0 KiB     A02C  ssd
   2               8            8199   32.0 MiB    A026  persist
   3            8200            8455   1024.0 KiB  A01F  misc
   4            8456            8583   512.0 KiB   A02D  keystore
   5            8584            8711   512.0 KiB   FFFF  frp
   6            8712         8397319   32.0 GiB    A038  system_a
   7         8397320        16785927   32.0 GiB    FFFF  system_b
   8        16785928        29595642   48.9 GiB    A03A  userdata

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>