### PR TITLE
Mount RB5 partitions to get firmware

### DIFF
--- a/recipes-bsp/firmware/files/lib-firmware-modem.service
+++ b/recipes-bsp/firmware/files/lib-firmware-modem.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Mount partition with preflashed firmware ('modem_a')
+ConditionPathExists=/lib/firmware/modem
+Before=systemd-udevd-control.socket
+After=local-fs-pre.target
+Before=local-fs.target
+Before=umount.target
+Conflicts=umount.target
+DefaultDependencies=no
+
+[Install]
+WantedBy=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+# sde4 = modem_a
+ExecStart=mount -t vfat -o ro /dev/sde4 /lib/firmware/modem
+ExecStop=umount /lib/firmware/modem

--- a/recipes-bsp/firmware/files/lib-firmware-system.service
+++ b/recipes-bsp/firmware/files/lib-firmware-system.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Mount partition with system root for for firmware files ('system_a')
+ConditionPathExists=/lib/firmware/system
+Before=systemd-udevd-control.socket
+After=local-fs-pre.target
+Before=local-fs.target
+Before=umount.target
+Conflicts=umount.target
+DefaultDependencies=no
+
+[Install]
+WantedBy=local-fs.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=true
+# sda6 = system_a
+ExecStart=mount -t ext4 -o ro /dev/sda6 /lib/firmware/system
+ExecStop=umount /lib/firmware/system

--- a/recipes-bsp/firmware/firmware-qcom-rb5_1.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-rb5_1.0.bb
@@ -38,7 +38,7 @@ do_install() {
         install -d  ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
         install -m 0444 adsp.b* adsp.mdt adspr.jsn adspua.jsn ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
         install -m 0444 cdsp.b* cdsp.mdt cdspr.jsn ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
-        install -m 0444 slpi.b* slpi.mdt ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
+        install -m 0444 slpi.b* slpi.mdt slpir.jsn slpius.jsn ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
         install -m 0444 venus.b* venus.mdt ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
 
         install -m 0444 verinfo/Ver_Info.txt ${D}${nonarch_base_libdir}/firmware/qcom/sm8250

--- a/recipes-bsp/firmware/firmware-qcom-rb5_1.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-rb5_1.0.bb
@@ -31,6 +31,18 @@ do_install() {
     if [ -n "${ADRENO_URI}" ] ; then
         install -d  ${D}${nonarch_base_libdir}/firmware/qcom
         install -m 0444 ./lib/firmware/a650_*.* ${D}${nonarch_base_libdir}/firmware/qcom
+    else
+        install -d ${D}${nonarch_base_libdir}/firmware/qcom
+        install -d ${D}${nonarch_base_libdir}/firmware/system
+
+        install -d ${D}${systemd_system_unitdir}
+        install -m 0644 ${WORKDIR}/lib-firmware-system.service ${D}${systemd_system_unitdir}
+
+        # Symlink firmware to proper paths.
+        for img in a650_gmu.bin a650_sqe.fw a650_zap.mdt a650_zap.elf a650_zap.b00 a650_zap.b01 a650_zap.b02
+        do
+            ln -s ../system/lib/firmware/${img} ${D}${nonarch_base_libdir}/firmware/qcom
+        done
     fi
 
     if [ -n "${NHLOS_URI}" ] ; then
@@ -92,4 +104,7 @@ python () {
     uri = d.getVar("ADRENO_URI")
     if uri != None and uri != "":
         d.appendVar("SRC_URI", " ${SRC_URI_ADRENO}")
+    else:
+        d.appendVar("SRC_URI", " file://lib-firmware-system.service")
+        d.appendVar("SYSTEMD_SERVICE_" + d.getVar("PN"), " lib-firmware-system.service")
 }


### PR DESCRIPTION
This PR enables using pre-flashed partitions (modem_a, system_a) to get firmware files. Unfortunately this has to be started early (before) udev, so it is neither possible to use mount units (as systemd does not know about block devices yet) nor possible to use meaningful names (/dev/block/by-partlabel/FOO).