### PR TITLE
linux: add linux-linaro-qcomlt_5.9.bb kernel for RB5

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.9.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.9.bb
@@ -1,0 +1,14 @@
+# Copyright (C) 2014-2019 Linaro
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "Linaro Qualcomm Landing team 5.9 Kernel"
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+require recipes-kernel/linux/linux-linaro-qcom.inc
+require recipes-kernel/linux/linux-qcom-bootimg.inc
+
+LOCALVERSION ?= "-linaro-lt-qcom"
+SRCBRANCH ?= "release/rb5/qcomlt-5.9"
+SRCREV ?= "6d5a9a5da79684f69e4c66a7cf9108ab4e77025f"
+
+COMPATIBLE_MACHINE = "(sm8250)"


### PR DESCRIPTION
RB5 boards are not fully supported by the main release 5.7 kernel, so
add separate version built from RB5-specific release branch.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>