### PR TITLE
recipes-graphics: Fix mesa-git build

### DIFF
--- a/recipes-graphics/mesa/files/0001-src-util-disk_cache_os.c-Add-missing-headers-for-ope.patch
+++ b/recipes-graphics/mesa/files/0001-src-util-disk_cache_os.c-Add-missing-headers-for-ope.patch
@@ -1,0 +1,79 @@
+From 3609301ce9ada728259388cadd508b8e9f4473e4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?An=C3=ADbal=20Lim=C3=B3n?= <anibal.limon@linaro.org>
+Date: Wed, 14 Oct 2020 14:45:20 -0500
+Subject: [PATCH] src/util/disk_cache_os.c: Add missing headers for open/fcntl
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Fixes, strict musl build [1],
+
+...
+17:25:31 ../git/src/util/disk_cache_os.c: In function 'disk_cache_load_item':
+17:25:31 ../git/src/util/disk_cache_os.c:526:9: error: implicit declaration of function 'open'; did you mean 'popen'? [-Werror=implicit-function-declaration]
+17:25:31   526 |    fd = open(filename, O_RDONLY | O_CLOEXEC);
+17:25:31       |         ^~~~
+17:25:31       |         popen
+17:25:31 ../git/src/util/disk_cache_os.c:526:24: error: 'O_RDONLY' undeclared (first use in this function)
+17:25:31   526 |    fd = open(filename, O_RDONLY | O_CLOEXEC);
+17:25:31       |                        ^~~~~~~~
+17:25:31 ../git/src/util/disk_cache_os.c:526:24: note: each undeclared identifier is reported only once for each function it appears in
+17:25:31 ../git/src/util/disk_cache_os.c:526:35: error: 'O_CLOEXEC' undeclared (first use in this function); did you mean 'MFD_CLOEXEC'?
+17:25:31   526 |    fd = open(filename, O_RDONLY | O_CLOEXEC);
+17:25:31       |                                   ^~~~~~~~~
+17:25:31       |                                   MFD_CLOEXEC
+17:25:31 ../git/src/util/disk_cache_os.c: In function 'disk_cache_write_item_to_disk':
+17:25:31 ../git/src/util/disk_cache_os.c:666:28: error: 'O_WRONLY' undeclared (first use in this function)
+17:25:31   666 |    fd = open(filename_tmp, O_WRONLY | O_CLOEXEC | O_CREAT, 0644);
+17:25:31       |                            ^~~~~~~~
+17:25:31 ../git/src/util/disk_cache_os.c:666:39: error: 'O_CLOEXEC' undeclared (first use in this function); did you mean 'MFD_CLOEXEC'?
+17:25:31   666 |    fd = open(filename_tmp, O_WRONLY | O_CLOEXEC | O_CREAT, 0644);
+17:25:31       |                                       ^~~~~~~~~
+17:25:31       |                                       MFD_CLOEXEC
+17:25:31 ../git/src/util/disk_cache_os.c:666:51: error: 'O_CREAT' undeclared (first use in this function)
+17:25:31   666 |    fd = open(filename_tmp, O_WRONLY | O_CLOEXEC | O_CREAT, 0644);
+17:25:31       |                                                   ^~~~~~~
+17:25:31 ../git/src/util/disk_cache_os.c:705:30: error: 'O_RDONLY' undeclared (first use in this function)
+17:25:31   705 |    fd_final = open(filename, O_RDONLY | O_CLOEXEC);
+17:25:31       |                              ^~~~~~~~
+17:25:31 ../git/src/util/disk_cache_os.c: In function 'disk_cache_mmap_cache_index':
+17:25:31 ../git/src/util/disk_cache_os.c:902:20: error: 'O_RDWR' undeclared (first use in this function)
+17:25:31   902 |    fd = open(path, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
+17:25:31       |                    ^~~~~~
+17:25:31 ../git/src/util/disk_cache_os.c:902:29: error: 'O_CREAT' undeclared (first use in this function)
+17:25:31   902 |    fd = open(path, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
+17:25:31       |                             ^~~~~~~
+17:25:31 ../git/src/util/disk_cache_os.c:902:39: error: 'O_CLOEXEC' undeclared (first use in this function); did you mean 'MFD_CLOEXEC'?
+17:25:31   902 |    fd = open(path, O_RDWR | O_CREAT | O_CLOEXEC, 0644);
+17:25:31       |                                       ^~~~~~~~~
+17:25:31       |                                       MFD_CLOEXEC
+17:25:31 cc1: some warnings being treated as errors
+...
+
+[1] https://ci.linaro.org/job/lt-qcom-openembedded-meta-qcom-master-premerge/MACHINE=qrb5165-rb5,TCLIBC=musl,label=docker-buster-amd64/87/console
+
+Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>
+
+Upstream-status: Submitted [https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/7146]
+---
+ src/util/disk_cache_os.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/util/disk_cache_os.c b/src/util/disk_cache_os.c
+index d48fe877c56..c4ee186b519 100644
+--- a/src/util/disk_cache_os.c
++++ b/src/util/disk_cache_os.c
+@@ -28,6 +28,10 @@
+ #include <stdbool.h>
+ #include <stddef.h>
+ #include <stdlib.h>
++#include <sys/types.h>
++#include <sys/stat.h>
++#include <dirent.h>
++#include <fcntl.h>
+ 
+ #include "zlib.h"
+ 
+-- 
+2.28.0
+

--- a/recipes-graphics/mesa/files/fix-meson-config-compat.patch
+++ b/recipes-graphics/mesa/files/fix-meson-config-compat.patch
@@ -1,4 +1,4 @@
-From ae96da4146570ebe9b0a9e68ac209cda6f1fb7ff Mon Sep 17 00:00:00 2001
+From 61d70cfa52df2a434196875ab0c0b67d2ffe2293 Mon Sep 17 00:00:00 2001
 From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
 Date: Wed, 2 Sep 2020 15:37:55 -0500
 Subject: [PATCH] mesa: adapt meson script to restore compatibility with
@@ -15,7 +15,7 @@ Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
  1 file changed, 3 insertions(+), 3 deletions(-)
 
 diff --git a/meson_options.txt b/meson_options.txt
-index 0fc28d69c93..c29e73b62ca 100644
+index c9d9d4d13bf..e3fe51aa371 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -52,7 +52,7 @@ option(
@@ -36,12 +36,12 @@ index 0fc28d69c93..c29e73b62ca 100644
      'swrast', 'v3d', 'vc4', 'etnaviv', 'tegra', 'i915', 'svga', 'virgl',
      'swr', 'panfrost', 'iris', 'lima', 'zink'
    ],
-@@ -172,7 +172,7 @@ option(
+@@ -179,7 +179,7 @@ option(
    'vulkan-drivers',
    type : 'array',
    value : ['auto'],
--  choices : ['auto', 'amd', 'freedreno', 'intel', 'swrast'],
-+  choices : ['', 'auto', 'amd', 'freedreno', 'intel', 'swrast'],
+-  choices : ['auto', 'amd', 'broadcom', 'freedreno', 'intel', 'swrast'],
++  choices : ['', 'auto', 'amd', 'broadcom', 'freedreno', 'intel', 'swrast'],
    description : 'List of vulkan drivers to build. If this is set to auto all drivers applicable to the target OS/architecture will be built'
  )
  option(

--- a/recipes-graphics/mesa/mesa_git.bb
+++ b/recipes-graphics/mesa/mesa_git.bb
@@ -8,10 +8,11 @@ SRC_URI = "git://gitlab.freedesktop.org/mesa/mesa.git;protocol=https \
            file://0005-vc4-use-intmax_t-for-formatted-output-of-timespec-me.patch \
            file://0001-meson-misdetects-64bit-atomics-on-mips-clang.patch \
            file://fix-meson-config-compat.patch \
+           file://0001-src-util-disk_cache_os.c-Add-missing-headers-for-ope.patch \
            "
 LIC_FILES_CHKSUM = "file://docs/license.rst;md5=9aa1bc48c9826ad9fdb16661f6930496"
 
-SRCREV = "61b714a42ee676fe03b383c0caf050169e404c7d"
+SRCREV = "3424e17b9a9beca85c0ef60e195eb544faea8995"
 #SRCREV_sm8250 = "${AUTOREV}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
Latest mesa rev 3424e17b9a9beca85c0ef60e195eb544faea8995 broke the
build.

- Update fix-meson-config-compat.patch patch to add broadcom target.
- Add 0001-src-util-disk_cache_os.c-Add-missing-headers-for-ope.patch to
  fix musl build, submitted to [1].

[1] https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/7146.