### PR TITLE
RB5-related fixes

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-rb5_1.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-rb5_1.0.bb
@@ -50,7 +50,7 @@ do_install() {
         install -d  ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
         install -m 0444 adsp.b* adsp.mdt adspr.jsn adspua.jsn ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
         install -m 0444 cdsp.b* cdsp.mdt cdspr.jsn ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
-        install -m 0444 slpi.b* slpi.mdt slpir.jsn slpius.jsn ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
+        install -m 0444 slpi.b* slpi.mdt ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
         install -m 0444 venus.b* venus.mdt ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
 
         install -m 0444 verinfo/Ver_Info.txt ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
@@ -72,7 +72,7 @@ do_install() {
             done
             ln -s ../../modem/image/${base}.mdt ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
         done
-        for img in adspr adspua cdspr slpir slpius
+        for img in adspr adspua cdspr
         do
             ln -s ../../modem/image/${img}.jsn ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
         done

--- a/recipes-kernel/linux/linux-linaro-qcomlt-dev.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-dev.bb
@@ -12,9 +12,10 @@ require recipes-kernel/linux/linux-linaro-qcom.inc
 require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 SRCBRANCH ?= "integration-linux-qcomlt"
-SRCREV ?= "${AUTOREV}"
+#SRCREV ?= "${AUTOREV}"
+SRCREV = "7b0c8f86e1ef16d58c582de5a0f0331f82640096"
 
-LINUX_VERSION = "5.8-rc+"
+LINUX_VERSION = "5.10-rc+"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
 # Wifi firmware has a recognizable arch :( 


### PR DESCRIPTION
- don't try packaging slipir/slpiua.jsn
- bump linux-linaro-qcomlt-dev version