### PR TITLE
recipes-kernel: Add Linux 5.9 support for apq8016|apq8096|sdm845

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.9.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.9.bb
@@ -8,7 +8,11 @@ require recipes-kernel/linux/linux-linaro-qcom.inc
 require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 LOCALVERSION ?= "-linaro-lt-qcom"
-SRCBRANCH ?= "release/rb5/qcomlt-5.9"
-SRCREV ?= "6d5a9a5da79684f69e4c66a7cf9108ab4e77025f"
 
-COMPATIBLE_MACHINE = "(sm8250)"
+SRCBRANCH ?= "release/qcomlt-5.9"
+SRCREV ?= "fca727995a6800a2c0f07313e3e0917cffdf0e36"
+
+SRCBRANCH_sm8250 = "release/rb5/qcomlt-5.9"
+SRCREV_sm8250 = "6d5a9a5da79684f69e4c66a7cf9108ab4e77025f"
+
+COMPATIBLE_MACHINE = "(apq8016|apq8096|sdm845|sm8250)"


### PR DESCRIPTION
Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>