### PR TITLE
recipes-kernel: Linux 5.9 (apq8016|apq8096|sdm845) bump to v5.9.6

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.9.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.9.bb
@@ -10,7 +10,7 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 LOCALVERSION ?= "-linaro-lt-qcom"
 
 SRCBRANCH ?= "release/qcomlt-5.9"
-SRCREV ?= "fca727995a6800a2c0f07313e3e0917cffdf0e36"
+SRCREV ?= "690b905759f07336f750f783958d47dc11b201a9"
 
 SRCBRANCH_sm8250 = "release/rb5/qcomlt-5.9"
 SRCREV_sm8250 = "6d5a9a5da79684f69e4c66a7cf9108ab4e77025f"


### PR DESCRIPTION
No Landing team changes only v5.9.2..v5.9.6 window.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>
(cherry picked from commit 8f1091909d27d7497d3f203d20ac5dd4d948926a)
Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>