### PR TITLE
recipes-support: rmtfs bump to rev 1cc12d3

### DIFF
--- a/recipes-support/rmtfs/rmtfs_git.bb
+++ b/recipes-support/rmtfs/rmtfs_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=ca25dbf5ebfc1a058bfc657c895aac2f"
 
 inherit systemd
 
-SRCREV = "3449744146b0a1b68810b81bd51fe5ef285e2388"
+SRCREV = "1cc12d3dc1f251f6d3151970621a06fdd013a1d0"
 SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https"
 DEPENDS = "qmic-native qrtr udev"
 


### PR DESCRIPTION
Fixes,

1cc12d3 storage: Use storage_close() to free up resources on exit
bf5cb9f rproc: Make start & stop threads detached
30f5dfb rproc: NUL-terminate the modalias
8a1d24a rproc: Make state update errors more helpful

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>
(cherry picked from commit 181fef98c6a063321669bf0c3d9a5d943f658755)
Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>