### PR TITLE
Separate qca-swiss-army-knife from firmware-qcom-dragonboard845c

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
@@ -4,14 +4,12 @@ LICENSE = "Proprietary"
 LIC_FILES_CHKSUM = "file://LICENSE.qcom.txt;md5=cbbe399f2c983ad51768f4561587f000"
 
 SRC_URI = "https://releases.linaro.org/96boards/dragonboard845c/qualcomm/firmware/RB3_firmware_${PV}.zip \
-           git://github.com/alimon/qca-swiss-army-knife \
            file://generate_board-2_json.sh"
 SRC_URI[md5sum] = "ad69855a1275547b16d94a1b5405ac62"
 SRC_URI[sha256sum] = "4289d2f2a7124b104d0274879e702aae9b1e50c42eec3747f8584c6744ef65e3"
-SRCREV = "0c01a2abc3e9855b71f0fbea2c335011104d9ec0"
 
 PACKAGE_ARCH = "${MACHINE_ARCH}"
-DEPENDS += "bash-native"
+DEPENDS += "bash-native qca-swiss-army-knife-native"
 inherit python3native
 
 S = "${WORKDIR}"
@@ -21,7 +19,7 @@ do_compile() {
     mkdir -p bdf
     cp ./38-bdwlan_split/bdwlan*.* bdf
     bash generate_board-2_json.sh bdf board-2.json
-    python3 git/tools/scripts/ath10k/ath10k-bdencoder -c board-2.json -o board-2.bin
+    python3 "${STAGING_BINDIR_NATIVE}/ath10k-bdencoder" -c board-2.json -o board-2.bin
 }
 
 do_install() {

--- a/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/0001-ath10k-bdencoder-Switch-to-python3.patch
+++ b/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/0001-ath10k-bdencoder-Switch-to-python3.patch
@@ -1,0 +1,146 @@
+From 71d960adea6e5287ac80e976e58865f59328f6c4 Mon Sep 17 00:00:00 2001
+From: Sven Eckelmann <sven@narfation.org>
+Date: Wed, 14 Oct 2020 15:52:02 +0200
+Subject: [PATCH 1/2] ath10k-bdencoder: Switch to python3
+
+Python 2.x is EOL since January 2020. The first distributions already
+started to drop the interpreters from their next distribution release. Just
+add some minor changes to make it python3 compatible.
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+---
+ tools/scripts/ath10k/ath10k-bdencoder | 35 ++++++++++++++-------------
+ 1 file changed, 18 insertions(+), 17 deletions(-)
+
+diff --git a/tools/scripts/ath10k/ath10k-bdencoder b/tools/scripts/ath10k/ath10k-bdencoder
+index 5f41a6be9446..1635e87b6f5f 100755
+--- a/tools/scripts/ath10k/ath10k-bdencoder
++++ b/tools/scripts/ath10k/ath10k-bdencoder
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/python3
+ #
+ # Copyright (c) 2015 Qualcomm Atheros, Inc.
+ # Copyright (c) 2018, The Linux Foundation. All rights reserved.
+@@ -33,7 +33,7 @@ import mailbox
+ MAX_BUF_LEN = 2000000
+ 
+ # the signature length also includes null byte and padding
+-ATH10K_BOARD_SIGNATURE = "QCA-ATH10K-BOARD"
++ATH10K_BOARD_SIGNATURE = b"QCA-ATH10K-BOARD"
+ ATH10K_BOARD_SIGNATURE_LEN = 20
+ 
+ PADDING_MAGIC = 0x6d
+@@ -83,7 +83,7 @@ def add_ie(buf, offset, id, value):
+ def xclip(msg):
+     p = subprocess.Popen(['xclip', '-selection', 'clipboard'],
+                          stdin=subprocess.PIPE)
+-    p.communicate(msg)
++    p.communicate(msg.encode())
+ 
+ 
+ # to workaround annoying python feature of returning negative hex values
+@@ -105,7 +105,8 @@ class BoardName():
+     def parse_ie(buf, offset, length):
+         self = BoardName()
+         fmt = '<%ds' % length
+-        (self.name, ) = struct.unpack_from(fmt, buf, offset)
++        (name, ) = struct.unpack_from(fmt, buf, offset)
++        self.name = name.decode()
+ 
+         logging.debug('BoardName.parse_ie(): offset %d length %d self %s' %
+                       (offset, length, self))
+@@ -310,7 +311,7 @@ class BoardContainer:
+                 allnames.append(name)
+ 
+     def _add_signature(self, buf, offset):
+-        signature = ATH10K_BOARD_SIGNATURE + '\0'
++        signature = ATH10K_BOARD_SIGNATURE + b'\0'
+         length = len(signature)
+         pad_len = padding_needed(length)
+         length = length + pad_len
+@@ -321,7 +322,7 @@ class BoardContainer:
+             struct.pack_into('<B', padding, i, PADDING_MAGIC)
+ 
+         fmt = '<%ds%ds' % (len(signature), pad_len)
+-        struct.pack_into(fmt, buf, offset, signature.encode(), padding.raw)
++        struct.pack_into(fmt, buf, offset, signature, padding.raw)
+         offset += length
+ 
+         # make sure ATH10K_BOARD_SIGNATURE_LEN is correct
+@@ -445,7 +446,7 @@ def cmd_extract(args):
+         b['data'] = filename
+         mapping.append(b)
+ 
+-        f = open(filename, 'w')
++        f = open(filename, 'wb')
+         f.write(board.data.data)
+         f.close()
+ 
+@@ -483,11 +484,11 @@ def diff_boardfiles(filename1, filename2, diff):
+ 
+     container1 = BoardContainer().open(filename1)
+     (temp1_fd, temp1_pathname) = tempfile.mkstemp()
+-    os.write(temp1_fd, container1.get_summary(sort=True))
++    os.write(temp1_fd, container1.get_summary(sort=True).encode())
+ 
+     container2 = BoardContainer().open(filename2)
+     (temp2_fd, temp2_pathname) = tempfile.mkstemp()
+-    os.write(temp2_fd, container2.get_summary(sort=True))
++    os.write(temp2_fd, container2.get_summary(sort=True).encode())
+ 
+     # this function is used both with --diff and --diffstat
+     if diff:
+@@ -509,7 +510,7 @@ def diff_boardfiles(filename1, filename2, diff):
+             print('Failed to run wdiff: %s' % (e))
+             return 1
+ 
+-        result += '%s\n' % (output)
++        result += '%s\n' % (output.decode())
+ 
+     # create simple statistics about changes in board images
+ 
+@@ -577,7 +578,7 @@ def cmd_add_board(args):
+     new_filename = args.add_board[1]
+     new_names = args.add_board[2:]
+ 
+-    f = open(new_filename, 'r')
++    f = open(new_filename, 'rb')
+     new_data = f.read()
+     f.close()
+ 
+@@ -620,15 +621,15 @@ def cmd_add_mbox(args):
+             name = filename.rstrip(BIN_SUFFIX)
+             board_files[name] = part.get_payload(decode=True)
+ 
+-        print 'Found mail "%s" with %d board files' % (msg['Subject'],
+-                                                       len(board_files))
++        print('Found mail "%s" with %d board files' % (msg['Subject'],
++                                                       len(board_files)))
+ 
+         # copy the original file for diff
+         (temp_fd, temp_pathname) = tempfile.mkstemp()
+         shutil.copyfile(board_filename, temp_pathname)
+ 
+         container = BoardContainer.open(board_filename)
+-        for name, data in board_files.iteritems():
++        for name, data in board_files.items():
+             names = [name]
+             container.add_board(data, names)
+ 
+@@ -650,9 +651,9 @@ def cmd_add_mbox(args):
+ 
+         os.remove(temp_pathname)
+ 
+-        print '----------------------------------------------'
+-        print applied_msg
+-        print '----------------------------------------------'
++        print('----------------------------------------------')
++        print(applied_msg)
++        print('----------------------------------------------')
+ 
+         xclip(applied_msg)
+ 
+-- 
+2.29.2
+

--- a/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/0002-ath10k-bdencoder-Add-option-to-switch-to-ath11k-mode.patch
+++ b/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/0002-ath10k-bdencoder-Add-option-to-switch-to-ath11k-mode.patch
@@ -1,0 +1,116 @@
+From 68fd447a4d1e137307927fb9c0d9e05c6559bc96 Mon Sep 17 00:00:00 2001
+From: Sven Eckelmann <sven@narfation.org>
+Date: Wed, 14 Oct 2020 17:26:19 +0200
+Subject: [PATCH 2/2] ath10k-bdencoder: Add option to switch to ath11k mode
+
+The board-2.bin also exists on ath11k but there is no encoder available at
+the moment. Just use an option to change the two positions where the ath11k
+differs from the ath10k board-2.bin
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+[DB: fixed firmware url]
+Signed-off-by: Dmitry Baryshkov <dbaryshkov@gmail.com>
+---
+ tools/scripts/ath10k/ath10k-bdencoder | 35 ++++++++++++++++++++++++---
+ 1 file changed, 31 insertions(+), 4 deletions(-)
+
+diff --git a/tools/scripts/ath10k/ath10k-bdencoder b/tools/scripts/ath10k/ath10k-bdencoder
+index 1635e87b6f5f..d613f6340bf9 100755
+--- a/tools/scripts/ath10k/ath10k-bdencoder
++++ b/tools/scripts/ath10k/ath10k-bdencoder
+@@ -34,6 +34,8 @@ MAX_BUF_LEN = 2000000
+ 
+ # the signature length also includes null byte and padding
+ ATH10K_BOARD_SIGNATURE = b"QCA-ATH10K-BOARD"
++ATH11K_BOARD_SIGNATURE = b"QCA-ATH11K-BOARD"
++BOARD_SIGNATURE = b''
+ ATH10K_BOARD_SIGNATURE_LEN = 20
+ 
+ PADDING_MAGIC = 0x6d
+@@ -44,6 +46,7 @@ TYPE_LENGTH_SIZE = 8
+ BIN_SUFFIX = '.bin'
+ 
+ ATH10K_FIRMWARE_URL = 'https://github.com/kvalo/ath10k-firmware/commit'
++ATH11K_FIRMWARE_URL = 'https://github.com/kvalo/ath11k-firmware/commit'
+ 
+ ATH10K_BD_IE_BOARD = 0
+ ATH10K_BD_IE_BOARD_EXT = 1
+@@ -311,7 +314,7 @@ class BoardContainer:
+                 allnames.append(name)
+ 
+     def _add_signature(self, buf, offset):
+-        signature = ATH10K_BOARD_SIGNATURE + b'\0'
++        signature = BOARD_SIGNATURE + b'\0'
+         length = len(signature)
+         pad_len = padding_needed(length)
+         length = length + pad_len
+@@ -343,10 +346,10 @@ class BoardContainer:
+ 
+         offset = 0
+ 
+-        fmt = '<%dsb' % (len(ATH10K_BOARD_SIGNATURE))
++        fmt = '<%dsb' % (len(BOARD_SIGNATURE))
+         (signature, null) = struct.unpack_from(fmt, buf, offset)
+ 
+-        if signature != ATH10K_BOARD_SIGNATURE or null != 0:
++        if signature != BOARD_SIGNATURE or null != 0:
+             print("invalid signature found in %s" % name)
+             return 1
+ 
+@@ -600,6 +603,11 @@ def git_get_head_id():
+ 
+ 
+ def cmd_add_mbox(args):
++    if args.mode == 10:
++        firmware_url = ATH10K_FIRMWARE_URL
++    elif args.mode == 11:
++        firmware_url = ATH11K_FIRMWARE_URL
++
+     board_filename = args.add_mbox[0]
+     mbox_filename = args.add_mbox[1]
+ 
+@@ -658,8 +666,19 @@ def cmd_add_mbox(args):
+         xclip(applied_msg)
+ 
+ 
++def mode_parse(v):
++    if v == 'ath10k':
++        return 10
++    elif v == 'ath11k':
++        return 11
++    else:
++        raise argparse.ArgumentTypeError('ath10k or ath11k expected.')
++
++
+ def main():
+-    description = '''ath10k board-N.bin files manegement tool
++    global BOARD_SIGNATURE
++
++    description = '''ath10k/ath11k board-N.bin files management tool
+ 
+ ath10k-bdencoder is for creating (--create), listing (--info) and
+ comparing (--diff, --diffstat) ath10k board-N.bin files. The
+@@ -709,12 +728,20 @@ can use --extract switch to see examples from real board-N.bin files.
+     parser.add_argument("-o", "--output", metavar="BOARD_FILE",
+                         help='name of the output file, otherwise the default is: %s' %
+                         (DEFAULT_BOARD_FILE))
++    parser.add_argument("-m", "--mode", metavar='MODE',
++                        help='select between ath10k and ath11k mode (default: ath10k)',
++                        default=10, type=mode_parse)
+ 
+     args = parser.parse_args()
+ 
+     if args.verbose:
+         logging.basicConfig(level=logging.DEBUG)
+ 
++    if args.mode == 10:
++        BOARD_SIGNATURE = ATH10K_BOARD_SIGNATURE
++    elif args.mode == 11:
++        BOARD_SIGNATURE = ATH11K_BOARD_SIGNATURE
++
+     if args.create:
+         return cmd_create(args)
+     elif args.extract:
+-- 
+2.29.2
+

--- a/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife_git.bb
+++ b/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife_git.bb
@@ -1,0 +1,21 @@
+SUMMARY = "A set of utilities to help QCA driver development."
+HOMEPAGE = "https://github.com/qca/qca-swiss-army-knife"
+SECTION = "devel"
+
+LICENSE = "ISC"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=884c3f3a874b2a0cfa283c7db0e5d604"
+
+SRCREV = "0c01a2abc3e9855b71f0fbea2c335011104d9ec0"
+SRC_URI = " \
+	git://github.com/qca/${BPN}.git;branch=master;protocol=https \
+"
+
+PV = "0.0+${SRCPV}"
+S = "${WORKDIR}/git"
+
+do_install () {
+	install -d ${D}/${bindir}
+	install -m 0755 tools/scripts/*/* ${D}/${bindir}
+}
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife_git.bb
+++ b/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife_git.bb
@@ -5,9 +5,11 @@ SECTION = "devel"
 LICENSE = "ISC"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=884c3f3a874b2a0cfa283c7db0e5d604"
 
-SRCREV = "0c01a2abc3e9855b71f0fbea2c335011104d9ec0"
+SRCREV = "5ede3cc07e9a52f115101c28f833242b772eeaab"
 SRC_URI = " \
 	git://github.com/qca/${BPN}.git;branch=master;protocol=https \
+	file://0001-ath10k-bdencoder-Switch-to-python3.patch \
+	file://0002-ath10k-bdencoder-Add-option-to-switch-to-ath11k-mode.patch \
 "
 
 PV = "0.0+${SRCPV}"


### PR DESCRIPTION
On RB5 ath11k module requires board data not present in linux-firmware archive. Add support for generating it at build time.