### PR TITLE
firmware-qcom-rb5: use sda7 instead of sda6 as the system partition

### DIFF
--- a/recipes-bsp/firmware/files/lib-firmware-system.service
+++ b/recipes-bsp/firmware/files/lib-firmware-system.service
@@ -14,6 +14,8 @@ WantedBy=local-fs.target
 [Service]
 Type=oneshot
 RemainAfterExit=true
-# sda6 = system_a
-ExecStart=mount -t ext4 -o ro /dev/sda6 /lib/firmware/system
+# sda7:
+#  - system_b with older partition scheme
+#  - single system with newer partition cheme
+ExecStart=mount -t ext4 -o ro /dev/sda7 /lib/firmware/system
 ExecStop=umount /lib/firmware/system


### PR DESCRIPTION
As a followup to 5cdb497e1b99 ("qrb5165-rb5.conf: switch to using
PARTLABEL=userdata for rootfs") use sda7 as system partition holding
a650 firmware.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>