### PR TITLE
linux-firmware: install lt9611uxc firmware

### DIFF
--- a/conf/machine/qrb5165-rb5.conf
+++ b/conf/machine/qrb5165-rb5.conf
@@ -13,7 +13,7 @@ SERIAL_CONSOLE ?= "115200 ttyMSM0"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     kernel-modules \
-    firmware-qcom-rb5 \
+    firmware-qcom-rb5 linux-firmware-lt9611uxc \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \


### PR DESCRIPTION
While we are waiting for lt9611uxc firmware to be accepted into
linux-firmware repo, bbappend respective recipe to download and install
lt9611uxc firmware file.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>