### PR TITLE
Fix QA issues in qca-swiss-army-knife packages

### DIFF
--- a/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/0001-read-powers-port-to-python3.patch
+++ b/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/0001-read-powers-port-to-python3.patch
@@ -1,0 +1,212 @@
+From 4ffa07ff681c628750ba7c66e8a97f5f57b35fa0 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dbaryshkov@gmail.com>
+Date: Thu, 17 Dec 2020 00:37:39 +0300
+Subject: [PATCH 1/3] read-powers: port to python3
+
+Signed-off-by: Dmitry Baryshkov <dbaryshkov@gmail.com>
+---
+ tools/scripts/ath9k/read-powers | 74 ++++++++++++++++-----------------
+ 1 file changed, 37 insertions(+), 37 deletions(-)
+
+diff --git a/tools/scripts/ath9k/read-powers b/tools/scripts/ath9k/read-powers
+index 1d430e78b695..535747db8f0b 100755
+--- a/tools/scripts/ath9k/read-powers
++++ b/tools/scripts/ath9k/read-powers
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python3
+ #
+ # Copyright (c) 2010 Atheros Communications Inc.
+ #
+@@ -117,7 +117,7 @@ def powertx_rate1 (val):
+ 	ofdm_rates["12"] = (val >> 16) & 0xff
+ 	ofdm_rates["18"] = (val >> 24) & 0xff
+ 
+-	print "%010s: 0x%08x" % ("Rate 1", val)
++	print("%010s: 0x%08x" % ("Rate 1", val))
+ 
+ def powertx_rate2 (val):
+ 	ofdm_rates["24"] = (val >> 0) & 0xff;
+@@ -125,7 +125,7 @@ def powertx_rate2 (val):
+ 	ofdm_rates["48"] = (val >> 16) & 0xff
+ 	ofdm_rates["54"] = (val >> 24) & 0xff
+ 
+-	print "%010s: 0x%08x" % ("Rate 2", val)
++	print("%010s: 0x%08x" % ("Rate 2", val))
+ 
+ def powertx_rate3 (val):
+ 	cck_rates["1L"]  = (val >> 0)  & 0xff;	
+@@ -134,7 +134,7 @@ def powertx_rate3 (val):
+ 	cck_rates["2L"]  = (val >> 16) & 0xff;
+ 	cck_rates["2S"]  = (val >> 24) & 0xff;
+ 
+-	print "%010s: 0x%08x" % ("Rate 3", val)
++	print("%010s: 0x%08x" % ("Rate 3", val))
+ 
+ def powertx_rate4 (val):
+ 	cck_rates["5.5L"] = (val >> 0)  & 0xff;
+@@ -142,7 +142,7 @@ def powertx_rate4 (val):
+ 	cck_rates["11L"]  = (val >> 16) & 0xff
+ 	cck_rates["11S"]  = (val >> 24) & 0xff
+ 
+-	print "%010s: 0x%08x" % ("Rate 4", val)
++	print("%010s: 0x%08x" % ("Rate 4", val))
+ 
+ def powertx_rate5 (val):
+ 	mcs_rates_ht20["0"]  = (val >> 0) & 0xff;
+@@ -165,7 +165,7 @@ def powertx_rate5 (val):
+ 
+ 	mcs_rates_ht20["5"]  = (val >> 24) & 0xff
+ 
+-	print "%010s: 0x%08x" % ("Rate 5", val)
++	print("%010s: 0x%08x" % ("Rate 5", val))
+ 
+ def powertx_rate6 (val):
+ 	mcs_rates_ht20["6"]  = (val >> 0)  & 0xff;
+@@ -173,7 +173,7 @@ def powertx_rate6 (val):
+ 	mcs_rates_ht20["12"] = (val >> 16) & 0xff
+ 	mcs_rates_ht20["13"] = (val >> 24) & 0xff
+ 
+-	print "%010s: 0x%08x" % ("Rate 6", val)
++	print("%010s: 0x%08x" % ("Rate 6", val))
+ 
+ def powertx_rate7 (val):
+ 	mcs_rates_ht40["0"]  = (val >> 0) & 0xff;
+@@ -196,7 +196,7 @@ def powertx_rate7 (val):
+ 
+ 	mcs_rates_ht40["5"]  = (val >> 24) & 0xff
+ 
+-	print "%010s: 0x%08x" % ("Rate 7", val)
++	print("%010s: 0x%08x" % ("Rate 7", val))
+ 
+ def powertx_rate8 (val):
+ 	mcs_rates_ht40["6"]  = (val >> 0) & 0xff;
+@@ -204,7 +204,7 @@ def powertx_rate8 (val):
+ 	mcs_rates_ht40["12"] = (val >> 16) & 0xff
+ 	mcs_rates_ht40["13"] = (val >> 24) & 0xff
+ 
+-	print "%010s: 0x%08x" % ("Rate 8", val)
++	print("%010s: 0x%08x" % ("Rate 8", val))
+ 
+ # What is 40 dup CCK, 40 dup OFDM, 20 ext cck, 20 ext ODFM ?
+ def powertx_rate9 (val):
+@@ -213,7 +213,7 @@ def powertx_rate9 (val):
+ 	ext_dup_rates["20 ext CCK"]  = (val >> 16) & 0xff
+ 	ext_dup_rates["20 ext OFDM"] = (val >> 24) & 0xff
+ 
+-	print "%010s: 0x%08x" % ("Rate 9", val)
++	print("%010s: 0x%08x" % ("Rate 9", val))
+ 
+ def powertx_rate10 (val):
+ 	mcs_rates_ht20["14"] = (val >> 0) & 0xff;
+@@ -221,7 +221,7 @@ def powertx_rate10 (val):
+ 	mcs_rates_ht20["20"] = (val >> 16) & 0xff
+ 	mcs_rates_ht20["21"] = (val >> 24) & 0xff
+ 
+-	print "%010s: 0x%08x" % ("Rate 10", val)
++	print("%010s: 0x%08x" % ("Rate 10", val))
+ 
+ def powertx_rate11 (val):
+ 	mcs_rates_ht20["22"] = (val >> 0) & 0xff;
+@@ -230,7 +230,7 @@ def powertx_rate11 (val):
+ 	mcs_rates_ht40["22"] = (val >> 16) & 0xff
+ 	mcs_rates_ht40["23"] = (val >> 24) & 0xff
+ 
+-	print "%010s: 0x%08x" % ("Rate 11", val)
++	print("%010s: 0x%08x" % ("Rate 11", val))
+ 
+ def powertx_rate12 (val):
+ 	mcs_rates_ht40["14"] = (val >> 0) & 0xff;
+@@ -238,7 +238,7 @@ def powertx_rate12 (val):
+ 	mcs_rates_ht40["20"] = (val >> 16) & 0xff
+ 	mcs_rates_ht40["21"] = (val >> 24) & 0xff
+ 
+-	print "%010s: 0x%08x" % ("Rate 12", val)
++	print("%010s: 0x%08x" % ("Rate 12", val))
+ 
+ registers = {
+ 	"0x00a3c0" : powertx_rate1,
+@@ -256,43 +256,43 @@ registers = {
+ 	}
+ 
+ def process_cck_rates():
+-	print "CCK Rates"
+-	print "======================"
+-	for rate, double_dbm in cck_rates.iteritems():
++	print("CCK Rates")
++	print("======================")
++	for rate, double_dbm in cck_rates.items():
+ 		dbm = "%.2f dBm" % (double_dbm / 2)
+-		print "%010s %010s" % (rate + " Mbps", dbm)
++		print("%010s %010s" % (rate + " Mbps", dbm))
+ 
+ def process_ofdm_rates():
+-	print "OFDM Rates"
+-	print "======================"
+-	for rate, double_dbm in sorted(map(lambda (k,v): (int(k,0), v), ofdm_rates.iteritems())):
++	print("OFDM Rates")
++	print("======================")
++	for rate, double_dbm in sorted(ofdm_rates.items(), key=lambda i: int(i[0], 0)):
+ 		rate_s = "%s" % rate
+ 		dbm = "%.02f dBm" % (double_dbm / 2)
+-		print "%010s %010s" % (rate_s + " Mbps", dbm)
++		print("%010s %010s" % (rate_s + " Mbps", dbm))
+ 
+ def process_mcs_ht20_rates():
+-	print "MCS20 Rates"
+-	print "======================"
+-	for rate, double_dbm in sorted(map(lambda (k,v): (int(k,0), v), mcs_rates_ht20.iteritems())):
++	print("MCS20 Rates")
++	print("======================")
++	for rate, double_dbm in sorted(mcs_rates_ht20.items(), key=lambda i: int(i[0], 0)):
+ 		rate_s = "%s" % rate
+ 		dbm = "%.02f dBm" % (double_dbm / 2)
+-		print "%010s %010s" % ("MCS" + rate_s, dbm)
++		print("%010s %010s" % ("MCS" + rate_s, dbm))
+ 
+ 
+ def process_mcs_ht40_rates():
+-	print "MCS40 Rates"
+-	print "======================"
+-	for rate, double_dbm in sorted(map(lambda (k,v): (int(k,0), v), mcs_rates_ht40.iteritems())):
++	print("MCS40 Rates")
++	print("======================")
++	for rate, double_dbm in sorted(mcs_rates_ht40.items(), key=lambda i: int(i[0], 0)):
+ 		rate_s = "%s" % rate
+ 		dbm = "%.2f dBm" % (double_dbm / 2)
+-		print "%010s %010s" % ("MCS" + rate_s, dbm)
++		print("%010s %010s" % ("MCS" + rate_s, dbm))
+ 
+ def process_ext_dup_rates():
+-	print "EXT-DUP Rates"
+-	print "=========================="
+-	for rate, double_dbm in ext_dup_rates.iteritems():
++	print("EXT-DUP Rates")
++	print("==========================")
++	for rate, double_dbm in ext_dup_rates.items():
+ 		dbm = "%.2f dBm" % (double_dbm / 2)
+-		print "%015s %010s" % (rate, dbm)
++		print("%015s %010s" % (rate, dbm))
+ 
+ def print_power_reg (reg, val):
+ 	if not reg in map(lambda x: int(x, 0), registers.keys()):
+@@ -300,12 +300,12 @@ def print_power_reg (reg, val):
+ 	registers.get("0x%06x" % reg)(val)
+ 
+ try:
+-	print "Power register"
+-	print "======================"
++	print("Power register")
++	print("======================")
+ 	for line in sys.stdin.readlines():
+-		reg, val  = map(lambda x: int(x, 0), string.split(line))
++		reg, val  = map(lambda x: int(x, 0), line.split())
+ 		print_power_reg(reg, val)
+-	print "-------------------------------------"
++	print("-------------------------------------")
+ 
+ 	process_cck_rates()
+ 	process_ofdm_rates()
+-- 
+2.29.2
+

--- a/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/0002-ath10k-fwencoder-port-to-python3.patch
+++ b/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/0002-ath10k-fwencoder-port-to-python3.patch
@@ -1,0 +1,272 @@
+From 3d23932fd812e1ec7a989ca7e594fcf04d42c8a6 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dbaryshkov@gmail.com>
+Date: Thu, 17 Dec 2020 01:32:47 +0300
+Subject: [PATCH 2/3] ath10k-fwencoder: port to python3
+
+Signed-off-by: Dmitry Baryshkov <dbaryshkov@gmail.com>
+---
+ tools/scripts/ath10k/ath10k-fwencoder | 70 +++++++++++++--------------
+ 1 file changed, 35 insertions(+), 35 deletions(-)
+
+diff --git a/tools/scripts/ath10k/ath10k-fwencoder b/tools/scripts/ath10k/ath10k-fwencoder
+index 6934a694e832..bbbe0344f014 100755
+--- a/tools/scripts/ath10k/ath10k-fwencoder
++++ b/tools/scripts/ath10k/ath10k-fwencoder
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python3
+ #
+ # Copyright (c) 2012-2015 Qualcomm Atheros, Inc.
+ #
+@@ -30,7 +30,7 @@ import hashlib
+ 
+ DEFAULT_FW_API_VERSION = 4
+ 
+-ATH10K_SIGNATURE = "QCA-ATH10K"
++ATH10K_SIGNATURE = b"QCA-ATH10K"
+ MAX_LEN = 2000000
+ 
+ ATH10K_FW_IE_FW_VERSION = 0
+@@ -327,7 +327,7 @@ class Ath10kFirmwareContainer(object):
+         elif is_int(s):
+             version = s
+         else:
+-            print 'Error: Invalid HTT OP version: %s' % s
++            print('Error: Invalid HTT OP version: %s' % s)
+             return 1
+ 
+         self.htt_op_version = version
+@@ -337,7 +337,7 @@ class Ath10kFirmwareContainer(object):
+ 
+         # find value from the dict
+         try:
+-            name = [key for key, value in htt_op_version_map.iteritems()
++            name = [key for key, value in htt_op_version_map.items()
+                     if value == version][0]
+         except IndexError:
+             name = str(version)
+@@ -353,7 +353,7 @@ class Ath10kFirmwareContainer(object):
+         elif is_int(s):
+             version = s
+         else:
+-            print 'Error: Invalid WMI OP version: %s' % s
++            print('Error: Invalid WMI OP version: %s' % s)
+             return 1
+ 
+         self.wmi_op_version = version
+@@ -363,7 +363,7 @@ class Ath10kFirmwareContainer(object):
+ 
+         # find value from the dict
+         try:
+-            name = [key for key, value in wmi_op_version_map.iteritems()
++            name = [key for key, value in wmi_op_version_map.items()
+                     if value == version][0]
+         except IndexError:
+             name = str(version)
+@@ -376,7 +376,7 @@ class Ath10kFirmwareContainer(object):
+         enabled = []
+         for capa in self.features:
+             if capa not in feature_map:
+-                print "Error: '%s' not found from the feature map" % capa
++                print("Error: '%s' not found from the feature map" % capa)
+                 return 1
+ 
+             enabled.append(feature_map[capa])
+@@ -434,7 +434,7 @@ class Ath10kFirmwareContainer(object):
+         self.fw_version = fw_version
+         # reserve one byte for null
+         if len(self.fw_version) > ETHTOOL_FWVERS_LEN - 1:
+-            print 'Firmware version string too long: %d' % (len(self.fw_version))
++            print('Firmware version string too long: %d' % (len(self.fw_version)))
+             return 1
+ 
+     def get_fw_version(self):
+@@ -500,7 +500,7 @@ class Ath10kFirmwareContainer(object):
+             elif e == ATH10K_FW_IE_FW_CODE_SWAP_IMAGE:
+                 self.fw_code_swap_image = c.elements[e]
+             else:
+-                print "Unknown IE: ", e
++                print("Unknown IE: ", e)
+ 
+     def save(self, filename):
+         self.container = FirmwareContainer(ATH10K_SIGNATURE)
+@@ -585,7 +585,7 @@ def write_file(filename, buf):
+ def info(options, args):
+ 
+     if len(args) != 1:
+-        print 'Filename missing'
++        print('Filename missing')
+         return 1
+ 
+     filename = args[0]
+@@ -593,13 +593,13 @@ def info(options, args):
+     c = Ath10kFirmwareContainer()
+     c.load(filename)
+ 
+-    print c.get_summary()
++    print(c.get_summary())
+ 
+ 
+ def dump(options, args):
+ 
+     if len(args) != 1:
+-        print 'Filename missing'
++        print('Filename missing')
+         return 1
+ 
+     filename = args[0]
+@@ -607,34 +607,34 @@ def dump(options, args):
+     c = Ath10kFirmwareContainer()
+     c.load(filename)
+ 
+-    print "ath10k-fwencoder --create \\"
++    print("ath10k-fwencoder --create \\")
+ 
+     if c.get_fw_version():
+-        print "--firmware-version=%s \\" % c.get_fw_version()
++        print("--firmware-version=%s \\" % c.get_fw_version())
+ 
+     if c.get_timestamp() and options.show_timestamp:
+-        print "--timestamp=%u \\" % c.get_timestamp()
++        print("--timestamp=%u \\" % c.get_timestamp())
+ 
+     if c.get_features():
+-        print "--features=%s \\" % c.get_features()
++        print("--features=%s \\" % c.get_features())
+ 
+     if c.get_fw_image():
+         name = "athwlan.bin"
+-        print "--firmware=%s \\" % name
++        print("--firmware=%s \\" % name)
+ 
+     if c.get_otp_image():
+         name = "otp.bin"
+-        print "--otp=%s \\" % name
++        print("--otp=%s \\" % name)
+ 
+     if c.get_wmi_op_version():
+-        print '--set-wmi-op-version=%s \\' % c.get_wmi_op_version()
++        print('--set-wmi-op-version=%s \\' % c.get_wmi_op_version())
+ 
+     if c.get_htt_op_version():
+-        print '--set-htt-op-version=%s \\' % (c.get_htt_op_version())
++        print('--set-htt-op-version=%s \\' % (c.get_htt_op_version()))
+ 
+     if c.get_fw_code_swap_image():
+         name = "athwlan.codeswap.bin"
+-        print "--firmware-codeswap=%s \\" % name
++        print("--firmware-codeswap=%s \\" % name)
+ 
+     print
+ 
+@@ -642,7 +642,7 @@ def dump(options, args):
+ def extract(options, args):
+ 
+     if len(args) != 1:
+-        print 'Filename missing'
++        print('Filename missing')
+         return 1
+ 
+     filename = args[0]
+@@ -653,24 +653,24 @@ def extract(options, args):
+     if c.get_fw_image():
+         name = "athwlan.bin"
+         write_file(name, c.get_fw_image())
+-        print '%s extracted: %d B' % (name, len(c.get_fw_image()))
++        print('%s extracted: %d B' % (name, len(c.get_fw_image())))
+ 
+     if c.get_otp_image():
+         name = "otp.bin"
+         write_file(name, c.get_otp_image())
+-        print '%s extracted: %d B' % (name, len(c.get_otp_image()))
++        print('%s extracted: %d B' % (name, len(c.get_otp_image())))
+ 
+     if c.get_fw_code_swap_image():
+         name = "athwlan.codeswap.bin"
+         write_file(name, c.get_fw_code_swap_image())
+-        print '%s extracted: %d B' % (name, len(c.get_fw_code_swap_image()))
++        print('%s extracted: %d B' % (name, len(c.get_fw_code_swap_image())))
+ 
+     print
+ 
+ 
+ def modify(options, args):
+     if len(args) != 1:
+-        print 'Filename missing'
++        print('Filename missing')
+         return 1
+ 
+     filename = args[0]
+@@ -710,7 +710,7 @@ def modify(options, args):
+ 
+     file_len = c.save(filename)
+ 
+-    print '%s modified: %d B' % (filename, file_len)
++    print('%s modified: %d B' % (filename, file_len))
+ 
+ 
+ def create(options):
+@@ -752,25 +752,25 @@ def create(options):
+ 
+     file_len = c.save(output)
+ 
+-    print '%s created: %d B' % (output, file_len)
++    print('%s created: %d B' % (output, file_len))
+ 
+ 
+ def cmd_crc32(options, args):
+     if len(args) != 1:
+-        print 'Filename missing'
++        print('Filename missing')
+         return 1
+ 
+     filename = args[0]
+ 
+     f = open(filename, 'r')
+     buf = f.read()
+-    print '%08x' % (_crc32(buf))
++    print('%08x' % (_crc32(buf)))
+     f.close()
+ 
+ 
+ def cmd_diff(options, args):
+     if len(args) != 2:
+-        print 'Usage: ath10k-fwencoder --diff FILE FILE'
++        print('Usage: ath10k-fwencoder --diff FILE FILE')
+         return 1
+ 
+     filename1 = args[0]
+@@ -804,7 +804,7 @@ def cmd_diff(options, args):
+         logger.error('Failed to run wdiff: %s' % (e))
+         return 1
+ 
+-    print output
++    print(output)
+ 
+     os.close(temp1_fd)
+     os.close(temp2_fd)
+@@ -896,10 +896,10 @@ def main():
+         try:
+             return create(options)
+         except FWEncoderError as e:
+-            print 'Create failed: %s' % e
++            print('Create failed: %s' % e)
+             sys.exit(2)
+         except Exception as e:
+-            print 'Create failed: %s' % e
++            print('Create failed: %s' % e)
+             traceback.print_exc()
+             sys.exit(3)
+     elif options.dump:
+@@ -915,7 +915,7 @@ def main():
+     elif options.diff:
+         return cmd_diff(options, args)
+     else:
+-        print 'Action command missing'
++        print('Action command missing')
+         return 1
+ 
+ if __name__ == "__main__":
+-- 
+2.29.2
+

--- a/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/0003-scripts-port-to-python3.patch
+++ b/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife/0003-scripts-port-to-python3.patch
@@ -1,0 +1,34 @@
+From 26ca6eff75f78fec9efff4a69fca7103b97f1ab1 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dbaryshkov@gmail.com>
+Date: Thu, 17 Dec 2020 01:33:01 +0300
+Subject: [PATCH 3/3] scripts: port to python3
+
+Signed-off-by: Dmitry Baryshkov <dbaryshkov@gmail.com>
+---
+ tools/scripts/ath10k/ath10k-fw-repo | 2 +-
+ tools/scripts/ath11k/ath11k-fw-repo | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/tools/scripts/ath10k/ath10k-fw-repo b/tools/scripts/ath10k/ath10k-fw-repo
+index 00b6d859209a..4cf044c04c5a 100755
+--- a/tools/scripts/ath10k/ath10k-fw-repo
++++ b/tools/scripts/ath10k/ath10k-fw-repo
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python3
+ #
+ # Copyright (c) 2016 Qualcomm Atheros, Inc.
+ # Copyright (c) 2018, The Linux Foundation. All rights reserved.
+diff --git a/tools/scripts/ath11k/ath11k-fw-repo b/tools/scripts/ath11k/ath11k-fw-repo
+index 1ac6023aaf12..51ca33c5dd7b 100755
+--- a/tools/scripts/ath11k/ath11k-fw-repo
++++ b/tools/scripts/ath11k/ath11k-fw-repo
+@@ -1,4 +1,4 @@
+-#!/usr/bin/python
++#!/usr/bin/env python3
+ #
+ # Copyright (c) 2016 Qualcomm Atheros, Inc.
+ # Copyright (c) 2018,2020 The Linux Foundation. All rights reserved.
+-- 
+2.29.2
+

--- a/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife_git.bb
+++ b/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife_git.bb
@@ -21,3 +21,5 @@ do_install () {
 }
 
 BBCLASSEXTEND = "native nativesdk"
+
+RDEPENDS_${PN} += "perl python3-core"

--- a/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife_git.bb
+++ b/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife_git.bb
@@ -10,6 +10,9 @@ SRC_URI = " \
 	git://github.com/qca/${BPN}.git;branch=master;protocol=https \
 	file://0001-ath10k-bdencoder-Switch-to-python3.patch \
 	file://0002-ath10k-bdencoder-Add-option-to-switch-to-ath11k-mode.patch \
+	file://0001-read-powers-port-to-python3.patch \
+	file://0002-ath10k-fwencoder-port-to-python3.patch \
+	file://0003-scripts-port-to-python3.patch \
 "
 
 PV = "0.0+${SRCPV}"


### PR DESCRIPTION
Fix following QA issues in qca-swiss-army-knife packages:

```
ERROR: QA Issue: /usr/bin/ath10k-bdencoder contained in package qca-swiss-army-knife requires /usr/bin/python3, but no providers found in RDEPENDS_qca-swiss-army-knife? [file-rdeps]
ERROR: QA Issue: /usr/bin/read-powers contained in package qca-swiss-army-knife requires /usr/bin/python, but no providers found in RDEPENDS_qca-swiss-army-knife? [file-rdeps]
ERROR: QA Issue: /usr/bin/irq-watch contained in package qca-swiss-army-knife requires /usr/bin/perl, but no providers found in RDEPENDS_qca-swiss-army-knife? [file-rdeps]
```