### PR TITLE
Backport WiFi support on RB5

### DIFF
--- a/conf/machine/qrb5165-rb5.conf
+++ b/conf/machine/qrb5165-rb5.conf
@@ -14,6 +14,7 @@ SERIAL_CONSOLE ?= "115200 ttyMSM0"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     kernel-modules \
     firmware-qcom-rb5 \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \
 "

--- a/recipes-bsp/firmware/firmware-qcom-rb5_1.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-rb5_1.0.bb
@@ -54,6 +54,9 @@ do_install() {
         install -m 0444 slpi.b* slpi.mdt ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
         install -m 0444 venus.b* venus.mdt ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
 
+        install -d ${D}${nonarch_base_libdir}/firmware/ath11k/QCA6390/hw2.0/
+        install -m 0444 bdwlan.e04 ${D}${nonarch_base_libdir}/firmware/ath11k/QCA6390/hw2.0/board.bin
+
         install -m 0444 verinfo/Ver_Info.txt ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
         cd ..
     else
@@ -77,6 +80,9 @@ do_install() {
         do
             ln -s ../../modem/image/${img}.jsn ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
         done
+
+        install -d ${D}${nonarch_base_libdir}/firmware/ath11k/QCA6390/hw2.0/
+        ln -s ../../../modem/image/bdwlan.e04 ${D}${nonarch_base_libdir}/firmware/ath11k/QCA6390/hw2.0/board.bin
     fi
 }
 

--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.10.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.10.bb
@@ -10,6 +10,6 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 LOCALVERSION ?= "-linaro-lt-qcom"
 
 SRCBRANCH = "release/rb5/qcomlt-5.10"
-SRCREV = "cb90d0712c6eeaa8209de8c31d0cdcd0c5e2213d"
+SRCREV = "59db0bbc0b0399254e4a1a08566bed91b0bdc45a"
 
 COMPATIBLE_MACHINE = "(sm8250)"

--- a/recipes-kernel/linux/linux-qcom-bootimg.inc
+++ b/recipes-kernel/linux/linux-qcom-bootimg.inc
@@ -10,6 +10,7 @@ SD_BOOT_IMAGE_BASE_NAME = "boot-sd${KERNEL_IMAGE_NAME}"
 SD_BOOT_IMAGE_SYMLINK_NAME = "boot-sd-${KERNEL_IMAGE_LINK_NAME}"
 KERNEL_CMDLINE = "root=${1} rw rootwait console=${ttydev},${baudrate}n8"
 KERNEL_CMDLINE_append_dragonboard-845c = " clk_ignore_unused pd_ignore_unused"
+KERNEL_CMDLINE_append_qrb5165-rb5 = " pcie_pme=nomsi"
 
 # param ${1} partition where rootfs is located
 # param ${2} output boot image file name


### PR DESCRIPTION
Backport WiFi support for RB5 to dunfell branch. As we require linux-firmware backport, use next version.
