### PR TITLE
recipes-bsp: firmware-qcom-dragonboard845c fix installation of renesas

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
@@ -26,7 +26,7 @@ do_install() {
     install -d ${D}${nonarch_base_libdir}/firmware/
     install -d ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
 
-    install -m 0444 ./17-USB3-201-202-FW/K2026090.mem ${D}${nonarch_base_libdir}/firmware/
+    install -m 0444 ./17-USB3-201-202-FW/K2026090.mem ${D}${nonarch_base_libdir}/firmware/renesas_usb_fw.mem
     install -m 0444 ./18-adreno-fw/a630_zap*.* ${D}${nonarch_base_libdir}/firmware/qcom/
     install -m 0444 ./20-adsp_split/firmware/adsp*.* ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
     install -m 0444 ./21-cdsp_split/firmware/cdsp*.* ${D}${nonarch_base_libdir}/firmware/qcom/sdm845

--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.9.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.9.bb
@@ -10,7 +10,7 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 LOCALVERSION ?= "-linaro-lt-qcom"
 
 SRCBRANCH ?= "release/qcomlt-5.9"
-SRCREV ?= "dfc69bfc93c0d2f943d21340e55a61c391794a71"
+SRCREV ?= "ba7408fb46b8301cf4343dde955f45b2de885729"
 
 SRCBRANCH_sm8250 = "release/rb5/qcomlt-5.9"
 SRCREV_sm8250 = "6d5a9a5da79684f69e4c66a7cf9108ab4e77025f"


### PR DESCRIPTION
When renesas firmware loader landed upstream [1] there is a common name
for the firmware so install the K2026090.mem as renesas_usb_fw.mem.

[1] https://github.com/torvalds/linux/commit/a66d21d7dba84deeaf3b296c43eafc11094b6f09

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>