### PR TITLE
qrb5165-rb5.conf: add wireless-regdb-static to RRECOMMENDS

### DIFF
--- a/conf/machine/qrb5165-rb5.conf
+++ b/conf/machine/qrb5165-rb5.conf
@@ -14,7 +14,7 @@ SERIAL_CONSOLE ?= "115200 ttyMSM0"
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     kernel-modules \
     firmware-qcom-rb5 linux-firmware-lt9611uxc \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k wireless-regdb-static', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \
 "


### PR DESCRIPTION
The ath11k driver fails to start the device properly if regdb can not be
loaded. Add wireless-regdb-static to MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS
if wifi is enabled in DISTRO_FEATURES to make sure all images are able
to bootstrap the onboard QCA6390 (ath11k) device.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>