### PR TITLE
initramfs-test-image: add iw package

### DIFF
--- a/recipes-test/images/initramfs-test-image.bb
+++ b/recipes-test/images/initramfs-test-image.bb
@@ -14,6 +14,7 @@ PACKAGE_INSTALL = " \
     e2fsprogs-tune2fs \
     ethtool \
     gptfdisk \
+    iw \
     lava-test-shell \
     packagegroup-core-boot \
     pciutils \


### PR DESCRIPTION
Add iw package to initramfs-test-image to supplement wpa-supplicant and
to allow controlling of the wifi devices.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>