### PR TITLE
qrb5165-rb5.conf: enable linux-firmware-lt9611uxc

### DIFF
--- a/conf/machine/qrb5165-rb5.conf
+++ b/conf/machine/qrb5165-rb5.conf
@@ -13,7 +13,7 @@ SERIAL_CONSOLE ?= "115200 ttyMSM0"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     kernel-modules \
-    firmware-qcom-rb5 \
+    firmware-qcom-rb5 linux-firmware-lt9611uxc \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \


### PR DESCRIPTION
Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
(cherry picked from commit 78d549d0f0f4497df9b9b59bf06dfbcf6fcd986e)