### PR TITLE
recipes-kernel/linux: Linux 5.9 db{410,845}c bump to rev b5ff44498a19

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.9.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.9.bb
@@ -10,7 +10,7 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 LOCALVERSION ?= "-linaro-lt-qcom"
 
 SRCBRANCH ?= "release/qcomlt-5.9"
-SRCREV ?= "ba7408fb46b8301cf4343dde955f45b2de885729"
+SRCREV ?= "b5ff44498a19a685aa10a07ec67e3d12bc95a33a"
 
 SRCBRANCH_sm8250 = "release/rb5/qcomlt-5.9"
 SRCREV_sm8250 = "6d5a9a5da79684f69e4c66a7cf9108ab4e77025f"


### PR DESCRIPTION
Changes,

b5ff44498a19 Merge tag 'v5.9.16' into release/qcomlt-5.9
f6bb36622ffd usb: renesas-xhci: Revert "usb: renesas-xhci: remove version check
...

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>