### PR TITLE
fastrpc: fix packaging of default listeners

### DIFF
--- a/recipes-support/fastrpc/fastrpc_git.bb
+++ b/recipes-support/fastrpc/fastrpc_git.bb
@@ -5,7 +5,7 @@ SECTION = "devel"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://src/fastrpc_apps_user.c;beginline=1;endline=29;md5=f94f3a7beba14ae2f59f817e9634f891"
 
-SRCREV = "388d868b3146fa7ccbeb6aa8c71485ebbbf5e1b9"
+SRCREV = "bc36c705c9b057ca880a423021d3c19f02edeadd"
 SRC_URI = "git://git.linaro.org/landing-teams/working/qualcomm/fastrpc.git;branch=automake;protocol=https"
 
 PV = "0.0+${SRCPV}"
@@ -13,3 +13,14 @@ PV = "0.0+${SRCPV}"
 S = "${WORKDIR}/git"
 
 inherit autotools
+
+FILES_${PN} += " \
+    ${libdir}/libadsp_default_listener.so \
+    ${libdir}/libcdsp_default_listener.so \
+"
+
+FILES_${PN}-dev_remove = "${FILES_SOLIBSDEV}"
+FILES_${PN}-dev += " \
+    ${libdir}/libadsprpc.so \
+    ${libdir}/libcdsprpc.so \
+"


### PR DESCRIPTION
Default fastrpc listeners should be packaged as a part of fastrpc
package (rather than fastrpc-dev), where they land by default.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>

The patch `0001-src-Makefile.am-simplify-build-template.patch` is pending review by Srini.