### PR TITLE
mesa: do not enforce preference for sm8250

### DIFF
--- a/recipes-graphics/mesa/mesa_20.3.0-rc2.bb
+++ b/recipes-graphics/mesa/mesa_20.3.0-rc2.bb
@@ -32,4 +32,4 @@ PACKAGECONFIG[dri] = "-Ddri-drivers=${DRIDRIVERS}, -Ddri-drivers='', xorgproto l
 
 # Do not select this version by default
 DEFAULT_PREFERENCE = "-1"
-DEFAULT_PREFERENCE_sm8250 = "1"
+DEFAULT_PREFERENCE_sm8250 = ""


### PR DESCRIPTION
Having DEFAULT_PREFERENCE_sm8250 = "1" would enforce using this recipe
(20.3.0-rc2) for sm8250 boards. Set this to the empty string instead as
a way to be able to override DEFAULT_PREFERENCE = "-1" for sm8250, but
still use newer versions as they are available now.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>