### PR TITLE
recipes-kernel: Linux 5.10 bump to rev a58febc453b5

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.10.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.10.bb
@@ -10,6 +10,6 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 LOCALVERSION ?= "-linaro-lt-qcom"
 
 SRCBRANCH = "release/qcomlt-5.10"
-SRCREV = "ee5a8c43d825506df8e9e0bd3b050c460931351f"
+SRCREV = "a58febc453b5bcbf154d3ceb3b6769956d90110b"
 
 COMPATIBLE_MACHINE = "(apq8016|apq8096|sdm845|sm8250)"


### PR DESCRIPTION
Changes,

a58febc453b5 arch/arm64/configs/defconfig: Enable USB_DWC3_ULPI for db820c
23c320329d2e arm64: defconfig: Enable PM8916 watchdog driver
775d8cfc20a4 arch/arm64/configs/defconfig: enable POWER_RESET_QCOM_PON
5fbc47cc611a arm64: defconfig: Enable fastrpc, mailbox
c1c8cba7b722 arch/arm64/configs/defconfig: Enable BT_QCOMSMD as m for db410c
14d381093d5d ASoC: qcom: Fix broken support to MI2S TERTIARY and QUATERNARY
e2f02a85415a ASoC: hdmi-codec: Fix return value in hdmi_codec_set_jack()

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>