### PR TITLE
alsa-ucm-conf: refresh qrb5165-rb5 patches

### DIFF
--- a/recipes-multimedia/alsa/alsa-ucm-conf/0001-ucm2-codecs-lpass-add-codec-sequences-for-wsa-and-va.patch
+++ b/recipes-multimedia/alsa/alsa-ucm-conf/0001-ucm2-codecs-lpass-add-codec-sequences-for-wsa-and-va.patch
@@ -21,50 +21,55 @@ Signed-off-by: Srinivas Kandagatla <srinivas.kandagatla@linaro.org>
 
 diff --git a/ucm2/codecs/lpass/va-macro/DMIC0DisableSeq.conf b/ucm2/codecs/lpass/va-macro/DMIC0DisableSeq.conf
 new file mode 100644
-index 000000000000..457344e71e1b
+index 0000000..ec3f45a
 --- /dev/null
 +++ b/ucm2/codecs/lpass/va-macro/DMIC0DisableSeq.conf
-@@ -0,0 +1,3 @@
-+cset "name='VA DMIC MUX0' ZERO"
-+cset "name='VA_DEC0 Volume' 0"
-+cset "name='VA_AIF1_CAP Mixer DEC0' 0"
+@@ -0,0 +1,5 @@
++DisableSequence [
++	cset "name='VA DMIC MUX0' ZERO"
++	cset "name='VA_DEC0 Volume' 0"
++	cset "name='VA_AIF1_CAP Mixer DEC0' 0"
++]
 diff --git a/ucm2/codecs/lpass/va-macro/DMIC0EnableSeq.conf b/ucm2/codecs/lpass/va-macro/DMIC0EnableSeq.conf
 new file mode 100644
-index 000000000000..11b428f868ac
+index 0000000..bd6e8f5
 --- /dev/null
 +++ b/ucm2/codecs/lpass/va-macro/DMIC0EnableSeq.conf
-@@ -0,0 +1,3 @@
-+cset "name='VA DMIC MUX0' DMIC0"
-+cset "name='VA_AIF1_CAP Mixer DEC0' 1"
-+cset "name='VA_DEC0 Volume' 100"
+@@ -0,0 +1,5 @@
++EnableSequence [
++	cset "name='VA DMIC MUX0' DMIC0"
++	cset "name='VA_AIF1_CAP Mixer DEC0' 1"
++	cset "name='VA_DEC0 Volume' 100"
++]
 diff --git a/ucm2/codecs/lpass/wsa-macro/SpeakerDisableSeq.conf b/ucm2/codecs/lpass/wsa-macro/SpeakerDisableSeq.conf
 new file mode 100644
-index 000000000000..d84463e751fa
+index 0000000..1f27d4c
 --- /dev/null
 +++ b/ucm2/codecs/lpass/wsa-macro/SpeakerDisableSeq.conf
-@@ -0,0 +1,8 @@
-+cset "name='WSA_RX0 Digital Volume' 0"
-+cset "name='WSA_RX1 Digital Volume' 0"
-+cset "name='WSA_COMP1 Switch' 0"
-+cset "name='WSA_COMP2 Switch' 0"
-+cset "name='WSA_RX0 INP0' ZERO"
-+cset "name='WSA_RX1 INP0' ZERO"
-+cset "name='WSA RX0 MUX' ZERO"
-+cset "name='WSA RX1 MUX' ZERO"
+@@ -0,0 +1,10 @@
++DisableSequence [
++	cset "name='WSA_RX0 Digital Volume' 0"
++	cset "name='WSA_RX1 Digital Volume' 0"
++	cset "name='WSA_COMP1 Switch' 0"
++	cset "name='WSA_COMP2 Switch' 0"
++	cset "name='WSA_RX0 INP0' ZERO"
++	cset "name='WSA_RX1 INP0' ZERO"
++	cset "name='WSA RX0 MUX' ZERO"
++	cset "name='WSA RX1 MUX' ZERO"
++]
 diff --git a/ucm2/codecs/lpass/wsa-macro/SpeakerEnableSeq.conf b/ucm2/codecs/lpass/wsa-macro/SpeakerEnableSeq.conf
 new file mode 100644
-index 000000000000..4e9faceab70b
+index 0000000..618bab4
 --- /dev/null
 +++ b/ucm2/codecs/lpass/wsa-macro/SpeakerEnableSeq.conf
-@@ -0,0 +1,8 @@
-+cset "name='WSA RX0 MUX' AIF1_PB"
-+cset "name='WSA RX1 MUX' AIF1_PB"
-+cset "name='WSA_RX0 INP0' RX0"
-+cset "name='WSA_RX1 INP0' RX1"
-+cset "name='WSA_COMP1 Switch' 1"
-+cset "name='WSA_COMP2 Switch' 1"
-+cset "name='WSA_RX0 Digital Volume' 68"
-+cset "name='WSA_RX1 Digital Volume' 68"
--- 
-2.29.2
-
+@@ -0,0 +1,10 @@
++EnableSequence [
++	cset "name='WSA RX0 MUX' AIF1_PB"
++	cset "name='WSA RX1 MUX' AIF1_PB"
++	cset "name='WSA_RX0 INP0' RX0"
++	cset "name='WSA_RX1 INP0' RX1"
++	cset "name='WSA_COMP1 Switch' 1"
++	cset "name='WSA_COMP2 Switch' 1"
++	cset "name='WSA_RX0 Digital Volume' 68"
++	cset "name='WSA_RX1 Digital Volume' 68"
++]

--- a/recipes-multimedia/alsa/alsa-ucm-conf/0002-ucm2-add-support-to-for-Qualcomm-RB5-Platform.patch
+++ b/recipes-multimedia/alsa/alsa-ucm-conf/0002-ucm2-add-support-to-for-Qualcomm-RB5-Platform.patch
@@ -9,19 +9,19 @@ Onboard DMIC audio input.
 
 Signed-off-by: Srinivas Kandagatla <srinivas.kandagatla@linaro.org>
 ---
- ucm2/sm8250/HDMI.conf                         | 26 +++++++++++++
- ucm2/sm8250/HiFi.conf                         | 37 +++++++++++++++++++
- .../Qualcomm-RB5-WSA8815-Speakers-DMIC0.conf  | 11 ++++++
- 3 files changed, 74 insertions(+)
- create mode 100644 ucm2/sm8250/HDMI.conf
- create mode 100644 ucm2/sm8250/HiFi.conf
- create mode 100644 ucm2/sm8250/Qualcomm-RB5-WSA8815-Speakers-DMIC0.conf
+ ucm2/Qualcomm/sm8250/HDMI.conf                     | 26 ++++++++++++
+ ucm2/Qualcomm/sm8250/HiFi.conf                     | 46 ++++++++++++++++++++++
+ .../Qualcomm-RB5-WSA8815-Speakers-DMIC0.conf       | 11 ++++++
+ 3 files changed, 83 insertions(+)
+ create mode 100644 ucm2/Qualcomm/sm8250/HDMI.conf
+ create mode 100644 ucm2/Qualcomm/sm8250/HiFi.conf
+ create mode 100644 ucm2/Qualcomm/sm8250/Qualcomm-RB5-WSA8815-Speakers-DMIC0.conf
 
-diff --git a/ucm2/sm8250/HDMI.conf b/ucm2/sm8250/HDMI.conf
+diff --git a/ucm2/Qualcomm/sm8250/HDMI.conf b/ucm2/Qualcomm/sm8250/HDMI.conf
 new file mode 100644
-index 000000000000..a9594fd94af2
+index 0000000..a9594fd
 --- /dev/null
-+++ b/ucm2/sm8250/HDMI.conf
++++ b/ucm2/Qualcomm/sm8250/HDMI.conf
 @@ -0,0 +1,26 @@
 +# Use case configuration for RB5 board.
 +# Author: Srinivas Kandagatla <srinivas.kandagatla@linaro.org>
@@ -49,12 +49,12 @@ index 000000000000..a9594fd94af2
 +		PlaybackPriority 200
 +	}
 +}
-diff --git a/ucm2/sm8250/HiFi.conf b/ucm2/sm8250/HiFi.conf
+diff --git a/ucm2/Qualcomm/sm8250/HiFi.conf b/ucm2/Qualcomm/sm8250/HiFi.conf
 new file mode 100644
-index 000000000000..484bb49057e7
+index 0000000..a310402
 --- /dev/null
-+++ b/ucm2/sm8250/HiFi.conf
-@@ -0,0 +1,37 @@
++++ b/ucm2/Qualcomm/sm8250/HiFi.conf
+@@ -0,0 +1,46 @@
 +# Use case configuration for Qualcomm RB5.
 +# Author: Srinivas Kandagatla <srinivas.kandagatla@linaro.org>
 +
@@ -62,11 +62,14 @@ index 000000000000..484bb49057e7
 +
 +	EnableSequence [
 +		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 1"
-+		<codecs/wsa881x/DefaultEnableSeq.conf>
++		cset "name='MultiMedia3 Mixer VA_CODEC_DMA_TX_0' 1"
 +	]
++
++	Include.wsae.File "/codecs/wsa881x/DefaultEnableSeq.conf"
 +
 +	DisableSequence [
 +		cset "name='WSA_CODEC_DMA_RX_0 Audio Mixer MultiMedia2' 0"
++		cset "name='MultiMedia3 Mixer VA_CODEC_DMA_TX_0' 0"
 +	]
 +
 +	Value {
@@ -77,38 +80,41 @@ index 000000000000..484bb49057e7
 +SectionDevice."Speaker" {
 +	Comment "Speaker playback"
 +
-+	EnableSequence [
-+		<codecs/lpass/wsa-macro/SpeakerEnableSeq.conf>
-+		<codecs/wsa881x/SpeakerEnableSeq.conf>
-+	]
-+
-+	DisableSequence [
-+		<codecs/wsa881x/SpeakerDisableSeq.conf>
-+		<codecs/lpass/wsa-macro/SpeakerDisableSeq.conf>
-+	]
++	Include.lpasswsae.File "/codecs/lpass/wsa-macro/SpeakerEnableSeq.conf"
++	Include.wsae.File "/codecs/wsa881x/SpeakerEnableSeq.conf"
++	Include.wsad.File "/codecs/wsa881x/SpeakerDisableSeq.conf"
++	Include.lpasswsad.File "/codecs/lpass/wsa-macro/SpeakerDisableSeq.conf"
 +
 +	Value {
 +		PlaybackPriority 100
 +		PlaybackPCM "hw:${CardId},1"
 +	}
 +}
-diff --git a/ucm2/sm8250/Qualcomm-RB5-WSA8815-Speakers-DMIC0.conf b/ucm2/sm8250/Qualcomm-RB5-WSA8815-Speakers-DMIC0.conf
++
++SectionDevice."Mic" {
++	Comment "Mic"
++	Include.lpassvad.File "/codecs/lpass/va-macro/DMIC0EnableSeq.conf"
++	Include.lpassvad.File "/codecs/lpass/va-macro/DMIC0DisableSeq.conf"
++
++	Value {
++		CapturePriority 100
++		CapturePCM "hw:${CardId},2"
++	}
++}
+diff --git a/ucm2/Qualcomm/sm8250/Qualcomm-RB5-WSA8815-Speakers-DMIC0.conf b/ucm2/Qualcomm/sm8250/Qualcomm-RB5-WSA8815-Speakers-DMIC0.conf
 new file mode 100644
-index 000000000000..be2aea7aab22
+index 0000000..2fbca31
 --- /dev/null
-+++ b/ucm2/sm8250/Qualcomm-RB5-WSA8815-Speakers-DMIC0.conf
++++ b/ucm2/Qualcomm/sm8250/Qualcomm-RB5-WSA8815-Speakers-DMIC0.conf
 @@ -0,0 +1,11 @@
 +Syntax 3
 +
 +SectionUseCase."HiFi" {
-+	File "/sm8250/HiFi.conf"
++	File "/Qualcomm/sm8250/HiFi.conf"
 +	Comment "HiFi quality Music."
 +}
 +
 +SectionUseCase."HDMI" {
-+	File "/sm8250/HDMI.conf"
++	File "/Qualcomm/sm8250/HDMI.conf"
 +	Comment "HDMI output."
 +}
--- 
-2.29.2
-

--- a/recipes-multimedia/alsa/alsa-ucm-conf/0003-ucm.conf-support-KernelModule-CardLongName.conf-path.patch
+++ b/recipes-multimedia/alsa/alsa-ucm-conf/0003-ucm.conf-support-KernelModule-CardLongName.conf-path.patch
@@ -1,0 +1,28 @@
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Fri, 29 Jan 2021 15:31:35 +0300
+Subject: ucm.conf: support KernelModule/CardLongName.conf paths
+
+Add support for 'ucm2/module/${KernelModule}/${CardLongName}.conf'
+paths.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Change-Id: Ib006691e4b384543f97897c03fe575f8278e66f5
+---
+ ucm2/ucm.conf | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/ucm2/ucm.conf b/ucm2/ucm.conf
+index 9e78df1..a9613a2 100644
+--- a/ucm2/ucm.conf
++++ b/ucm2/ucm.conf
+@@ -53,6 +53,10 @@ If.driver {
+ 			False {
+ 				Define.KernelModulePath "class/sound/card${CardNumber}/device/driver/module"
+ 				Define.KernelModule "$${sys:$KernelModulePath}"
++				UseCasePath.modulelongname {
++					Directory "module/${var:KernelModule}"
++					File "${CardLongName}.conf"
++				}
+ 				UseCasePath.module {
+ 					Directory "module"
+ 					File "${var:KernelModule}.conf"

--- a/recipes-multimedia/alsa/alsa-ucm-conf/0004-module-add-new-symlink-for-Qualcomm-sdm845-driver.patch
+++ b/recipes-multimedia/alsa/alsa-ucm-conf/0004-module-add-new-symlink-for-Qualcomm-sdm845-driver.patch
@@ -1,0 +1,21 @@
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Fri, 29 Jan 2021 15:32:06 +0300
+Subject: module: add new symlink for Qualcomm/sdm845 driver
+
+Add module/snd_soc_sdm845 -> Qualcomm/sdm845 link.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Change-Id: I5325033f47ee131499ed406ec56284bbf2f58b8d
+---
+ ucm2/module/snd_soc_sdm845 | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 120000 ucm2/module/snd_soc_sdm845
+
+diff --git a/ucm2/module/snd_soc_sdm845 b/ucm2/module/snd_soc_sdm845
+new file mode 120000
+index 0000000..6800b66
+--- /dev/null
++++ b/ucm2/module/snd_soc_sdm845
+@@ -0,0 +1 @@
++../Qualcomm/sdm845
+\ No newline at end of file

--- a/recipes-multimedia/alsa/alsa-ucm-conf/0007-ucm2-module-add-snd_soc_sm8250-symlink.patch
+++ b/recipes-multimedia/alsa/alsa-ucm-conf/0007-ucm2-module-add-snd_soc_sm8250-symlink.patch
@@ -1,0 +1,19 @@
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Fri, 29 Jan 2021 15:41:39 +0300
+Subject: ucm2/module: add snd_soc_sm8250 symlink
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Change-Id: I9818a19ef812d715d65345ea3733f635d5505c2e
+---
+ ucm2/module/snd_soc_sm8250 | 1 +
+ 1 file changed, 1 insertion(+)
+ create mode 120000 ucm2/module/snd_soc_sm8250
+
+diff --git a/ucm2/module/snd_soc_sm8250 b/ucm2/module/snd_soc_sm8250
+new file mode 120000
+index 0000000..faf64f1
+--- /dev/null
++++ b/ucm2/module/snd_soc_sm8250
+@@ -0,0 +1 @@
++../Qualcomm/sm8250
+\ No newline at end of file

--- a/recipes-multimedia/alsa/alsa-ucm-conf_%.bbappend
+++ b/recipes-multimedia/alsa/alsa-ucm-conf_%.bbappend
@@ -3,4 +3,7 @@ FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
 SRC_URI_append_sm8250 = "\
 	file://0001-ucm2-codecs-lpass-add-codec-sequences-for-wsa-and-va.patch \
 	file://0002-ucm2-add-support-to-for-Qualcomm-RB5-Platform.patch \
+	file://0003-ucm.conf-support-KernelModule-CardLongName.conf-path.patch \
+	file://0004-module-add-new-symlink-for-Qualcomm-sdm845-driver.patch \
+	file://0007-ucm2-module-add-snd_soc_sm8250-symlink.patch \
 "


### PR DESCRIPTION
Refresh patches adding support for RB5 platform. As we are at it, move
data to new place (Qualcomm/sm8250) and put symbolic links necessary to
load it.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>