### PR TITLE
linux-linaro-qcomlt: add 5.11 version for sm8250 (RB5)

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.11.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.11.bb
@@ -1,0 +1,15 @@
+# Copyright (C) 2014-2020 Linaro
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+DESCRIPTION = "Linaro Qualcomm Landing team 5.11 Kernel"
+LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
+
+require recipes-kernel/linux/linux-linaro-qcom.inc
+require recipes-kernel/linux/linux-qcom-bootimg.inc
+
+LOCALVERSION ?= "-linaro-lt-qcom"
+
+SRCBRANCH = "release/rb5/qcomlt-5.11"
+SRCREV = "c53a93b858f8166115bbe728a9a2a39bf7d0a91d"
+
+COMPATIBLE_MACHINE = "(sm8250)"


### PR DESCRIPTION
For the next RB5 release add 5.11 linux-linaro-qcomlt recipe using
special release branch.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>