### PR TITLE
recipes-kernel: Linux 5.10 bump to rev 9ab492e76768

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.10.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.10.bb
@@ -10,6 +10,6 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 LOCALVERSION ?= "-linaro-lt-qcom"
 
 SRCBRANCH = "release/qcomlt-5.10"
-SRCREV = "3f30f43cd449a911c7f304078aa8464ec5eb0903"
+SRCREV = "9ab492e76768cd1bd9f2da52004ed537c8b329f3"
 
 COMPATIBLE_MACHINE = "(apq8016|apq8096|sdm845|sm8250)"


### PR DESCRIPTION
Changes,

9ab492e76768 arm64: defconfig: Enable QCOM audio as modules
67cf276de670 misc: fastrpc: restrict user apps from sending kernel RPC messages
b8ff783ddc4f misc: fastrpc: fix incorrect usage of dma_map_sgtable
fb0392de9ea6 arm64: dts: qcom: qrb5165-rb5: switch into using GPIO for SPI0 CS
00431b42fbd7 arm64: dts: qcom: sm8250: add pinctrl for SPI using GPIO as a CS
e207855faec3 spi-geni-qcom: fix spi_geni_transfer_one for SE case

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>
(cherry picked from commit 8a1f863618a6e56ae4e0b894cde5116c3f5d27cf)
Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>