### PR TITLE
recipes-kernel/linux/linux-linaro-qcomlt-dev: use AUTOREV

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt-dev.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-dev.bb
@@ -12,14 +12,15 @@ require recipes-kernel/linux/linux-linaro-qcom.inc
 require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 SRCBRANCH ?= "integration-linux-qcomlt"
-#SRCREV ?= "${AUTOREV}"
-SRCREV = "7b0c8f86e1ef16d58c582de5a0f0331f82640096"
 
-LINUX_VERSION = "5.10-rc+"
+# Set default SRCREV. it is statically set to the korg v3.7 tag, and
+# hence prevent network access during parsing. If linux-linaro-qcomlt-dev
+# is the preferred provider, they will be overridden to AUTOREV in following
+# anonymous python routine and resolved when the variables are finalized.
+SRCREV ?= '${@oe.utils.conditional("PREFERRED_PROVIDER_virtual/kernel", "linux-linaro-qcomlt-dev", "${AUTOREV}", "29594404d7fe73cd80eaa4ee8c43dcc53970c60e", d)}'
+
+LINUX_VERSION = "5.11+"
 PV = "${LINUX_VERSION}+git${SRCPV}"
 
 # Wifi firmware has a recognizable arch :( 
 ERROR_QA_remove = "arch"
-
-# Disable by default
-DEFAULT_PREFERENCE = "-1"


### PR DESCRIPTION
This kernel recipe builds the QCLT integration branch which is not a
*relase* branch, but is regularly rebased. With a fixed SRCREV the
build will often break. Instead let's use AUTOREV. While it's not
recommended, DEFAULT_PREFERENCE will ensure that this recipe is not
used unless it's explicitely required.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>