### PR TITLE
recipes-kernel: Linux 5.10 bump to 6afb1155f01d

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.10.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.10.bb
@@ -10,6 +10,6 @@ require recipes-kernel/linux/linux-qcom-bootimg.inc
 LOCALVERSION ?= "-linaro-lt-qcom"
 
 SRCBRANCH = "release/qcomlt-5.10"
-SRCREV = "9ab492e76768cd1bd9f2da52004ed537c8b329f3"
+SRCREV = "6afb1155f01df9871e14e4189d83d31000b308ee"
 
 COMPATIBLE_MACHINE = "(qcom)"


### PR DESCRIPTION
Changes,

6afb1155f01d venus: pm_helpers: Set opp clock name for v1
893d70f9ddce venus: hfi_parser: Don't initialize parser on v1
97e75989b610 thermal: cpufreq_cooling: freq_qos_update_request() returns < 0 on error
4aec9d8fb1a1 arm64: defconfig: Enable missing QCOM interconnect drivers

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>