### PR TITLE
recipes-test/images: initramfs-test-image allow to override NO_RECOMM…

### DIFF
--- a/recipes-test/images/initramfs-test-image.bb
+++ b/recipes-test/images/initramfs-test-image.bb
@@ -42,7 +42,7 @@ IMAGE_ROOTFS_SIZE = "8192"
 IMAGE_ROOTFS_EXTRA_SPACE = "0"
 
 # Disable installation of kernel and modules via packagegroup-core-boot
-NO_RECOMMENDATIONS = "1"
+NO_RECOMMENDATIONS ?= "1"
 
 # Enable local auto-login (on systemd) of the root user (local = serial port and
 # virtual console by default, can be configured).


### PR DESCRIPTION
…ENDATIONS

To be able specify installation of firmware and/or modules in
{auto,local}.conf.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>