### PR TITLE
qrb5165-rb5: use new rootfs partition

### DIFF
--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -14,8 +14,6 @@ KERNEL_DEVICETREE ?= "qcom/apq8016-sbc.dtb qcom/apq8096-db820c.dtb qcom/sdm845-d
 QCOM_BOOTIMG_PAGE_SIZE[apq8016-sbc] = "2048"
 QCOM_BOOTIMG_ROOTFS = "/dev/sda1"
 QCOM_BOOTIMG_ROOTFS[apq8016-sbc] = "/dev/mmcblk0p14"
-QCOM_BOOTIMG_ROOTFS[qrb5165-rb5] = "PARTLABEL=userdata"
-QCOM_BOOTIMG_ROOTFS[sm8250-rb5-dvt] = "PARTLABEL=userdata"
 SD_QCOM_BOOTIMG_ROOTFS[apq8016-sbc] = "/dev/mmcblk1p7"
 KERNEL_CMDLINE_EXTRA[sdm845-db845c] = "clk_ignore_unused pd_ignore_unused"
 

--- a/conf/machine/qrb5165-rb5.conf
+++ b/conf/machine/qrb5165-rb5.conf
@@ -22,9 +22,8 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 "
 # linux-firmware-qcom-adreno-a650 
 
-# 'userdata' is sda8 with older firmware/GPT and sda6 with newer firmware.
-# Allow kernel to resolve it on it's own.  Wipe it and use for our build.
-QCOM_BOOTIMG_ROOTFS ?= "PARTLABEL=userdata"
+# /dev/sda1 is 'rootfs' partition after installing the latest bootloader package from linaro
+QCOM_BOOTIMG_ROOTFS ?= "/dev/sda1"
 
 # UFS partitions setup with 4096 logical sector size
 EXTRA_IMAGECMD_ext4 += " -b 4096 "


### PR DESCRIPTION
Latest RB5 bootloader package provides updated partition scheme. It
removes Android partitions and adds single rootfs partition at
/dev/sda1. Switch to new rootfs partition.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>