### PR TITLE
qrb5165-rb5: use new rootfs partition

### DIFF
--- a/conf/machine/qrb5165-rb5.conf
+++ b/conf/machine/qrb5165-rb5.conf
@@ -21,9 +21,8 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 "
 # linux-firmware-qcom-adreno-a650 
 
-# 'userdata' is sda8 with older firmware/GPT and sda6 with newer firmware.
-# Allow kernel to resolve it on it's own.  Wipe it and use for our build.
-QCOM_BOOTIMG_ROOTFS ?= "PARTLABEL=userdata"
+# /dev/sda1 is 'rootfs' partition after installing the latest bootloader package from linaro
+QCOM_BOOTIMG_ROOTFS ?= "/dev/sda1"
 
 # UFS partitions setup with 4096 logical sector size
 EXTRA_IMAGECMD_ext4 += " -b 4096 "


### PR DESCRIPTION
Latest RB5 bootloader package provides updated partition scheme. It
removes Android partitions and adds single rootfs partition at
/dev/sda1. Switch to new rootfs partition.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
(cherry picked from commit 7b577f612750f1448e1b8250cf24782f933a9883)