### PR TITLE
recipes-test: Add new utilities to 'initramfs-test-image.bb'

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-test/images/initramfs-test-full-image.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-test/images/initramfs-test-full-image.bbappend
@@ -1,0 +1,8 @@
+PACKAGE_INSTALL += " \
+    crash \
+    devmem2 \
+    iozone3 \
+    libgpiod \
+    libgpiod-tools \
+    makedumpfile \
+"

--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -1,0 +1,37 @@
+require recipes-test/images/initramfs-tiny-image.bb
+
+DESCRIPTION = "Relatively larger ramdisk image for running tests (bootrr, etc)"
+export IMAGE_BASENAME = "initramfs-test-full-image"
+
+PACKAGE_INSTALL += " \
+    bluez5 \
+    coreutils \
+    dhcpcd \
+    diag \
+    e2fsprogs \
+    e2fsprogs-e2fsck \
+    e2fsprogs-mke2fs \
+    e2fsprogs-resize2fs \
+    e2fsprogs-tune2fs \
+    ethtool \
+    gptfdisk \
+    iw \
+    kexec-tools \
+    lava-test-shell \
+    libdrm-tests \
+    lsof \
+    ncurses \
+    ncurses-terminfo \
+    ncurses-terminfo-base \
+    pciutils \
+    pd-mapper \
+    qrtr \
+    rmtfs \
+    rt-tests \
+    stress-ng \
+    tqftpserv \
+    usbutils \
+    util-linux \
+    util-linux-chrt \
+    wpa-supplicant \
+"


### PR DESCRIPTION
Add following utilities to 'initramfs-test-image.bb':

-> For kexec/kdump analysis:
   - crash
   - makedumpfile
   - kexec
-> iozone3: for filesystem performance analysis.
-> cryptsetup: for crypto benchmarks.
-> util-linux: for 'gdisk', 'taskset', etc.
-> coreutils: mainly for 'dd' (as busybox 'dd' does not show performance
              figures).

Addition of the above tools results in an approximate increase of
6M in the resulting rootfs size (cpio.gz archive)

Before:
-------
$ ls -lah initramfs-test-image-qcom-armv8a-20210521045425.rootfs.cpio.gz
19M

After:
------
$ ls -lah initramfs-test-image-qcom-armv8a-20210521070020.rootfs.cpio.gz
25M

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>