### PR TITLE
conf/machine: Add initial support for SA8155P-ADP board

### DIFF
--- a/conf/machine/include/qcom-sa8155p.inc
+++ b/conf/machine/include/qcom-sa8155p.inc
@@ -1,0 +1,15 @@
+SOC_FAMILY = "sa8155p"
+require conf/machine/include/qcom-common.inc
+DEFAULTTUNE = "armv8-2a-crypto"
+require conf/machine/include/arm/arch-armv8-2a.inc
+
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    pd-mapper \
+    qrtr \
+    rmtfs \
+    tqftpserv \
+"
+
+MACHINE_EXTRA_RRECOMMENDS += " \
+    fastrpc \
+"

--- a/conf/machine/sa8155p-adp.conf
+++ b/conf/machine/sa8155p-adp.conf
@@ -1,0 +1,18 @@
+#@TYPE: Machine
+#@NAME: SA8155P-ADP
+#@DESCRIPTION: Machine configuration for the SA8155P-ADP development board, with Qualcomm Snapdragon 855 SM8150.
+
+require conf/machine/include/qcom-sa8155p.inc
+
+MACHINE_FEATURES = "usbhost usbgadget ext2"
+
+KERNEL_IMAGETYPE ?= "Image.gz"
+KERNEL_DEVICETREE ?= "qcom/sa8155p-adp.dtb"
+
+SERIAL_CONSOLE ?= "115200 ttyMSM0"
+
+# /dev/sda6 is 'userdata' partition for adp board, so wipe it and use for our build
+QCOM_BOOTIMG_ROOTFS ?= "/dev/sda6"
+
+# UFS partitions setup with 4096 logical sector size
+EXTRA_IMAGECMD:ext4 += " -b 4096 "

--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.14.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.14.bb
@@ -1,0 +1,9 @@
+# Copyright (C) 2014-2020 Linaro
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+require recipes-kernel/linux/linux-linaro-qcom.inc
+
+SRCBRANCH = "release/sa8155p-adp/qcomlt-5.14"
+SRCREV = "9f2bf2add46548ce1c77cd66cd3e828523fe96e8"
+
+COMPATIBLE_MACHINE = "(sa8155p)"


### PR DESCRIPTION
Add configuration files for SA8155P-ADP board which
uses the SM8150 SoC.

Here we create an include (.inc) file and a configuration
(.conf) file for the adp board.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>