### PR TITLE
layer.conf: set LAYERDEPENDS

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -8,6 +8,8 @@ BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 BBFILE_COLLECTIONS += "qcom"
 BBFILE_PATTERN_qcom := "^${LAYERDIR}/"
 BBFILE_PRIORITY_qcom = "5"
+
+LAYERDEPENDS_qcom = "core"
 LAYERSERIES_COMPAT_qcom = "zeus dunfell gatesgarth hardknott"
 
 BBFILES_DYNAMIC += " \


### PR DESCRIPTION
meta-qcom depends only oe-core, mark it explicitely. The layer has
additional dependencies on meta-oe or meta-networking, but they are
optional.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>