### PR TITLE
recipes-graphics: mesa_git update to rev 26677008b9a

### DIFF
--- a/recipes-graphics/mesa/files/0001-meson-misdetects-64bit-atomics-on-mips-clang.patch
+++ b/recipes-graphics/mesa/files/0001-meson-misdetects-64bit-atomics-on-mips-clang.patch
@@ -1,4 +1,4 @@
-From 96a676daf4640b6993551c70560723e51edc3828 Mon Sep 17 00:00:00 2001
+From efa754088b0df22d7d80636a52b20a728899b640 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Mon, 13 Jan 2020 15:23:47 -0800
 Subject: [PATCH] meson misdetects 64bit atomics on mips/clang

--- a/recipes-graphics/mesa/files/0001-meson.build-check-for-all-linux-host_os-combinations.patch
+++ b/recipes-graphics/mesa/files/0001-meson.build-check-for-all-linux-host_os-combinations.patch
@@ -1,7 +1,7 @@
-From aae6b7833f86c3504c0c4f880da503164e25ba4a Mon Sep 17 00:00:00 2001
+From 70e9b8b37448825d56698a76dff7a9bd07a92497 Mon Sep 17 00:00:00 2001
 From: Alistair Francis <alistair@alistair23.me>
 Date: Thu, 14 Nov 2019 13:04:49 -0800
-Subject: [PATCH 1/5] meson.build: check for all linux host_os combinations
+Subject: [PATCH] meson.build: check for all linux host_os combinations
 
 Make sure that we are also looking for our host_os combinations like
 linux-musl etc. when assuming support for DRM/KMS.
@@ -14,15 +14,16 @@ Signed-off-by: Anuj Mittal <anuj.mittal@intel.com>
 Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>
 Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
 Signed-off-by: Alistair Francis <alistair@alistair23.me>
+
 ---
  meson.build | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 932eb136681..efc61711f4d 100644
+index cfe011f0ca4..5f81d9702b9 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -153,7 +153,7 @@ with_any_opengl = with_opengl or with_gles1 or with_gles2
+@@ -155,7 +155,7 @@ with_any_opengl = with_opengl or with_gles1 or with_gles2
  # Only build shared_glapi if at least one OpenGL API is enabled
  with_shared_glapi = with_shared_glapi and with_any_opengl
  
@@ -31,7 +32,7 @@ index 932eb136681..efc61711f4d 100644
  
  dri_drivers = get_option('dri-drivers')
  if dri_drivers.contains('auto')
-@@ -970,7 +970,7 @@ if cc.compiles('__uint128_t foo(void) { return 0; }',
+@@ -984,7 +984,7 @@ if cc.compiles('__uint128_t foo(void) { return 0; }',
  endif
  
  # TODO: this is very incomplete
@@ -40,6 +41,3 @@ index 932eb136681..efc61711f4d 100644
    pre_args += '-D_GNU_SOURCE'
  elif host_machine.system() == 'sunos'
    pre_args += '-D__EXTENSIONS__'
--- 
-2.30.0
-

--- a/recipes-graphics/mesa/files/0002-meson.build-make-TLS-ELF-optional.patch
+++ b/recipes-graphics/mesa/files/0002-meson.build-make-TLS-ELF-optional.patch
@@ -1,4 +1,4 @@
-From 372820ee40ba52f03672477245fafa395dd29009 Mon Sep 17 00:00:00 2001
+From f0920dce5fd2e8b2eb28873f64b65f4a24cb440d Mon Sep 17 00:00:00 2001
 From: Alistair Francis <alistair@alistair23.me>
 Date: Wed, 2 Sep 2020 15:28:50 -0500
 Subject: [PATCH] meson.build: make TLS ELF optional
@@ -8,13 +8,14 @@ TLS GLX optional again" patch updated to the latest mesa.
 
 Upstream-Status: Inappropriate [configuration]
 Signed-off-by: Alistair Francis <alistair@alistair23.me>
+
 ---
  meson.build       | 4 +---
  meson_options.txt | 6 ++++++
  2 files changed, 7 insertions(+), 3 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 142f3839e91..d80d795bf66 100644
+index 5f81d9702b9..e5ecf107971 100644
 --- a/meson.build
 +++ b/meson.build
 @@ -449,9 +449,7 @@ endif
@@ -29,10 +30,10 @@ index 142f3839e91..d80d795bf66 100644
    use_elf_tls = true
  endif
 diff --git a/meson_options.txt b/meson_options.txt
-index 599a2b3fd89..11a4cc532b9 100644
+index fa6a9809e11..a3d690d5be6 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -426,6 +426,12 @@ option(
+@@ -427,6 +427,12 @@ option(
    value : true,
    description : 'Enable direct rendering in GLX and EGL for DRI',
  )
@@ -45,6 +46,3 @@ index 599a2b3fd89..11a4cc532b9 100644
  option(
    'prefer-iris',
    type : 'boolean',
--- 
-2.30.1
-

--- a/recipes-graphics/mesa/files/0003-Allow-enable-DRI-without-DRI-drivers.patch
+++ b/recipes-graphics/mesa/files/0003-Allow-enable-DRI-without-DRI-drivers.patch
@@ -1,4 +1,4 @@
-From 19f38c23dc290f2a820c7d2c8b880568cdf90154 Mon Sep 17 00:00:00 2001
+From c9ac28cabcdbcba1539498bd166d78db10f53326 Mon Sep 17 00:00:00 2001
 From: Fabio Berton <fabio.berton@ossystems.com.br>
 Date: Wed, 12 Jun 2019 14:18:31 -0300
 Subject: [PATCH] Allow enable DRI without DRI drivers
@@ -8,16 +8,17 @@ Upstream-Status: Pending
 Signed-off-by: Andrei Gherzan <andrei@gherzan.ro>
 Signed-off-by: Fabio Berton <fabio.berton@ossystems.com.br>
 Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
+
 ---
  meson.build       | 2 +-
  meson_options.txt | 6 ++++++
  2 files changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
-index af1f63041ce..224d930d4d5 100644
+index e5ecf107971..077af8eed31 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -188,7 +188,7 @@ with_dri_r100 = dri_drivers.contains('r100')
+@@ -186,7 +186,7 @@ with_dri_r100 = dri_drivers.contains('r100')
  with_dri_r200 = dri_drivers.contains('r200')
  with_dri_nouveau = dri_drivers.contains('nouveau')
  
@@ -27,7 +28,7 @@ index af1f63041ce..224d930d4d5 100644
  gallium_drivers = get_option('gallium-drivers')
  if gallium_drivers.contains('auto')
 diff --git a/meson_options.txt b/meson_options.txt
-index fbb86f3f896..a8b021d718e 100644
+index a3d690d5be6..d9a6f808bc2 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -41,6 +41,12 @@ option(
@@ -43,6 +44,3 @@ index fbb86f3f896..a8b021d718e 100644
  option(
    'dri-drivers',
    type : 'array',
--- 
-2.30.1
-

--- a/recipes-graphics/mesa/files/0004-Revert-mesa-Enable-asm-unconditionally-now-that-gen_.patch
+++ b/recipes-graphics/mesa/files/0004-Revert-mesa-Enable-asm-unconditionally-now-that-gen_.patch
@@ -1,4 +1,4 @@
-From 0686afe15146bf8bbde7a0ab60147cdb8edfe76c Mon Sep 17 00:00:00 2001
+From b6477a1e7f1b7ba227721c89b612d8e3479bf541 Mon Sep 17 00:00:00 2001
 From: Alistair Francis <alistair@alistair23.me>
 Date: Wed, 2 Sep 2020 15:31:59 -0500
 Subject: [PATCH] Revert "mesa: Enable asm unconditionally, now that
@@ -9,6 +9,7 @@ This reverts commit 20294dceebc23236e33b22578245f7e6f41b6997.
 
 Upstream-Status: Inappropriate [configuration]
 Signed-off-by: Alistair Francis <alistair@alistair23.me>
+
 ---
  Android.common.mk                   |  3 +
  Android.mk                          |  7 +++
@@ -19,10 +20,10 @@ Signed-off-by: Alistair Francis <alistair@alistair23.me>
  6 files changed, 83 insertions(+), 33 deletions(-)
 
 diff --git a/Android.common.mk b/Android.common.mk
-index 9141ef951d6..cec6f7888c3 100644
+index 7ef6a90a179..061de3bb147 100644
 --- a/Android.common.mk
 +++ b/Android.common.mk
-@@ -103,9 +103,12 @@ ifeq ($(shell test $(PLATFORM_SDK_VERSION) -ge 26 && echo true),true)
+@@ -104,9 +104,12 @@ ifeq ($(shell test $(PLATFORM_SDK_VERSION) -ge 26 && echo true),true)
  LOCAL_CFLAGS += -DHAVE_SYS_SHM_H
  endif
  
@@ -36,7 +37,7 @@ index 9141ef951d6..cec6f7888c3 100644
  ifeq ($(ARCH_ARM_HAVE_NEON),true)
  LOCAL_CFLAGS_arm += -DUSE_ARM_ASM
 diff --git a/Android.mk b/Android.mk
-index aa2e7f7610e..adc0db69584 100644
+index 07eba7b8316..25c531cb61c 100644
 --- a/Android.mk
 +++ b/Android.mk
 @@ -90,6 +90,13 @@ endif
@@ -54,12 +55,12 @@ index aa2e7f7610e..adc0db69584 100644
  MESA_ENABLE_LLVM := true
  endif
 diff --git a/meson.build b/meson.build
-index d80d795bf66..af1f63041ce 100644
+index 077af8eed31..664ce66d6b0 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -53,6 +53,9 @@ with_vulkan_icd_dir = get_option('vulkan-icd-dir')
+@@ -52,6 +52,9 @@ pre_args = [
+ with_vulkan_icd_dir = get_option('vulkan-icd-dir')
  with_tests = get_option('build-tests')
- with_glcpp_tests = get_option('enable-glcpp-tests')
  with_aco_tests = get_option('build-aco-tests')
 +with_valgrind = get_option('valgrind')
 +with_libunwind = get_option('libunwind')
@@ -67,7 +68,7 @@ index d80d795bf66..af1f63041ce 100644
  with_glx_read_only_text = get_option('glx-read-only-text')
  with_glx_direct = get_option('glx-direct')
  with_osmesa = get_option('osmesa')
-@@ -1210,41 +1213,68 @@ dep_ws2_32 = cc.find_library('ws2_32', required : with_platform_windows)
+@@ -1222,41 +1225,68 @@ dep_ws2_32 = cc.find_library('ws2_32', required : with_platform_windows)
  
  # TODO: shared/static? Is this even worth doing?
  
@@ -170,10 +171,10 @@ index d80d795bf66..af1f63041ce 100644
  endif
  
 diff --git a/meson_options.txt b/meson_options.txt
-index 11a4cc532b9..fbb86f3f896 100644
+index d9a6f808bc2..b83efcfe486 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -250,6 +250,12 @@ option(
+@@ -257,6 +257,12 @@ option(
    choices : ['auto', 'true', 'false', 'enabled', 'disabled'],
    description : 'Build support for OpenGL ES 2.x and 3.x'
  )
@@ -218,6 +219,3 @@ index 16153a3c5bd..ddfd03059c5 100644
  
  ifeq ($(ARCH_X86_HAVE_SSE4_1),true)
  LOCAL_WHOLE_STATIC_LIBRARIES := \
--- 
-2.30.1
-

--- a/recipes-graphics/mesa/mesa_git.bb
+++ b/recipes-graphics/mesa/mesa_git.bb
@@ -1,6 +1,6 @@
 require recipes-graphics/mesa/mesa.inc
 
-SRC_URI = "git://gitlab.freedesktop.org/mesa/mesa.git;protocol=https \
+SRC_URI = "git://gitlab.freedesktop.org/mesa/mesa.git;protocol=https;branch=main \
            file://0001-meson.build-check-for-all-linux-host_os-combinations.patch \
            file://0002-meson.build-make-TLS-ELF-optional.patch \
            file://0003-Allow-enable-DRI-without-DRI-drivers.patch \
@@ -9,7 +9,7 @@ SRC_URI = "git://gitlab.freedesktop.org/mesa/mesa.git;protocol=https \
            "
 LIC_FILES_CHKSUM = "file://docs/license.rst;md5=17a4ea65de7a9ab42437f3131e616a7f"
 
-SRCREV = "${@oe.utils.conditional("MESA_DEV", "1", "${AUTOREV}", "a084d012a9ee71049749a6209b0a1cd637e113e1", d)}"
+SRCREV = "${@oe.utils.conditional("MESA_DEV", "1", "${AUTOREV}", "26677008b9a7c0ef82f2a7f4b479d3cb06097c66", d)}"
 DEFAULT_PREFERENCE = "${@oe.utils.conditional("MESA_DEV", "1", "1", "-1", d)}"
 
 PLATFORMS_remove = "drm surfaceless"
@@ -19,7 +19,7 @@ DRIDRIVERS_class-native = "auto"
 DRIDRIVERS_class-nativesdk = "auto"
 
 S = "${WORKDIR}/git"
-PV = "20.4-dev+git${SRCPV}"
+PV = "2x.x-dev+git${SRCPV}"
 ERROR_QA_remove = "version-going-backwards"
 
 # Add package to install require files to run tests for mesa


### PR DESCRIPTION
- Update branch name to main.
- Update PV to 2x.x-dev recently mesa bump to 21.x versions so use 2x.x
  for our mesa_git dev build.
- Refresh patches to avoid warnings when apply.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>