### PR TITLE
conf/machine: Add linux-firmware-qca for dragonboard-820c

### DIFF
--- a/conf/machine/dragonboard-820c.conf
+++ b/conf/machine/dragonboard-820c.conf
@@ -16,6 +16,7 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     kernel-modules \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a530 mesa-driver-msm', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
     linux-firmware-qcom-venus-4.2 \
 "
 


### PR DESCRIPTION
To install qca/nvm_00440302.bin required for bluetooth.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>