### PR TITLE
lt9611uxc-upgrade script: Only cat firmware version when it exists

### DIFF
--- a/recipes-bsp/lt9611uxc-upgrade/lt9611uxc-upgrade/lt9611uxc-upgrade.sh
+++ b/recipes-bsp/lt9611uxc-upgrade/lt9611uxc-upgrade/lt9611uxc-upgrade.sh
@@ -13,7 +13,7 @@ if [ ! -d /sys/bus/i2c/drivers/lt9611uxc ] ; then
 fi
 
 for f in /sys/bus/i2c/drivers/lt9611uxc/* ; do
-	[ -L $f ] || continue
+	[ -e $f/lt9611uxc_firmware ] || continue
 	version=`cat $f/lt9611uxc_firmware`
 	if [ "$version" -lt "43" ] ; then
 		echo > $f/lt9611uxc_firmware


### PR DESCRIPTION
Update script to only execute cat in directories where lt9611uxc_firmware
exists.

On my system both module and 5-002b are symbolic links, thus the previous
script would cause the lt9611uxc firmware update systemd unit to fail because
the script would try to access lt9611uxc_firmware in the module directory and
return a failure which would cause the systemd service to be listed under
'systemctl list-units --failed'

Signed-off-by: Olivier Schonken <olivier.schonken@gmail.com>