### PR TITLE
recipes-graphics: mesa_git refresh patches and fix deqp filename

### DIFF
--- a/recipes-graphics/mesa/files/0001-meson-misdetects-64bit-atomics-on-mips-clang.patch
+++ b/recipes-graphics/mesa/files/0001-meson-misdetects-64bit-atomics-on-mips-clang.patch
@@ -1,4 +1,4 @@
-From efa754088b0df22d7d80636a52b20a728899b640 Mon Sep 17 00:00:00 2001
+From 994f33977973baeda1956d253827fc3953bfab55 Mon Sep 17 00:00:00 2001
 From: Khem Raj <raj.khem@gmail.com>
 Date: Mon, 13 Jan 2020 15:23:47 -0800
 Subject: [PATCH] meson misdetects 64bit atomics on mips/clang

--- a/recipes-graphics/mesa/files/0001-meson.build-check-for-all-linux-host_os-combinations.patch
+++ b/recipes-graphics/mesa/files/0001-meson.build-check-for-all-linux-host_os-combinations.patch
@@ -1,4 +1,4 @@
-From 70e9b8b37448825d56698a76dff7a9bd07a92497 Mon Sep 17 00:00:00 2001
+From fdcbfd2841eb34f44bdf51aeb4ef45811b66fd75 Mon Sep 17 00:00:00 2001
 From: Alistair Francis <alistair@alistair23.me>
 Date: Thu, 14 Nov 2019 13:04:49 -0800
 Subject: [PATCH] meson.build: check for all linux host_os combinations
@@ -20,10 +20,10 @@ Signed-off-by: Alistair Francis <alistair@alistair23.me>
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index cfe011f0ca4..5f81d9702b9 100644
+index ff333961a0d..5931260dd3d 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -155,7 +155,7 @@ with_any_opengl = with_opengl or with_gles1 or with_gles2
+@@ -158,7 +158,7 @@ with_any_opengl = with_opengl or with_gles1 or with_gles2
  # Only build shared_glapi if at least one OpenGL API is enabled
  with_shared_glapi = with_shared_glapi and with_any_opengl
  
@@ -32,7 +32,7 @@ index cfe011f0ca4..5f81d9702b9 100644
  
  dri_drivers = get_option('dri-drivers')
  if dri_drivers.contains('auto')
-@@ -984,7 +984,7 @@ if cc.compiles('__uint128_t foo(void) { return 0; }',
+@@ -1000,7 +1000,7 @@ if cc.compiles('__uint128_t foo(void) { return 0; }',
  endif
  
  # TODO: this is very incomplete

--- a/recipes-graphics/mesa/files/0002-meson.build-make-TLS-ELF-optional.patch
+++ b/recipes-graphics/mesa/files/0002-meson.build-make-TLS-ELF-optional.patch
@@ -1,4 +1,4 @@
-From f0920dce5fd2e8b2eb28873f64b65f4a24cb440d Mon Sep 17 00:00:00 2001
+From a9253ee295c4684e20aee6022bc9f26c5fc68856 Mon Sep 17 00:00:00 2001
 From: Alistair Francis <alistair@alistair23.me>
 Date: Wed, 2 Sep 2020 15:28:50 -0500
 Subject: [PATCH] meson.build: make TLS ELF optional
@@ -15,10 +15,10 @@ Signed-off-by: Alistair Francis <alistair@alistair23.me>
  2 files changed, 7 insertions(+), 3 deletions(-)
 
 diff --git a/meson.build b/meson.build
-index 5f81d9702b9..e5ecf107971 100644
+index 5931260dd3d..23a3cd66156 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -449,9 +449,7 @@ endif
+@@ -453,9 +453,7 @@ endif
  
  # Android uses emutls for versions <= P/28. For USE_ELF_TLS we need ELF TLS.
  use_elf_tls = false
@@ -28,12 +28,12 @@ index 5f81d9702b9..e5ecf107971 100644
 +if (not with_platform_android or get_option('platform-sdk-version') >= 29) and get_option('elf-tls')
    pre_args += '-DUSE_ELF_TLS'
    use_elf_tls = true
- endif
+ 
 diff --git a/meson_options.txt b/meson_options.txt
-index fa6a9809e11..a3d690d5be6 100644
+index 54e15e9f850..118eba3914d 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -427,6 +427,12 @@ option(
+@@ -439,6 +439,12 @@ option(
    value : true,
    description : 'Enable direct rendering in GLX and EGL for DRI',
  )

--- a/recipes-graphics/mesa/files/0003-Allow-enable-DRI-without-DRI-drivers.patch
+++ b/recipes-graphics/mesa/files/0003-Allow-enable-DRI-without-DRI-drivers.patch
@@ -1,4 +1,4 @@
-From c9ac28cabcdbcba1539498bd166d78db10f53326 Mon Sep 17 00:00:00 2001
+From 96fc2efc4d120fc2bdbc39cc0c656a939790b51e Mon Sep 17 00:00:00 2001
 From: Fabio Berton <fabio.berton@ossystems.com.br>
 Date: Wed, 12 Jun 2019 14:18:31 -0300
 Subject: [PATCH] Allow enable DRI without DRI drivers
@@ -15,10 +15,10 @@ Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
  2 files changed, 7 insertions(+), 1 deletion(-)
 
 diff --git a/meson.build b/meson.build
-index e5ecf107971..077af8eed31 100644
+index 23a3cd66156..f19e59c32fe 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -186,7 +186,7 @@ with_dri_r100 = dri_drivers.contains('r100')
+@@ -189,7 +189,7 @@ with_dri_r100 = dri_drivers.contains('r100')
  with_dri_r200 = dri_drivers.contains('r200')
  with_dri_nouveau = dri_drivers.contains('nouveau')
  
@@ -28,7 +28,7 @@ index e5ecf107971..077af8eed31 100644
  gallium_drivers = get_option('gallium-drivers')
  if gallium_drivers.contains('auto')
 diff --git a/meson_options.txt b/meson_options.txt
-index a3d690d5be6..d9a6f808bc2 100644
+index 118eba3914d..f7354104c4a 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
 @@ -41,6 +41,12 @@ option(

--- a/recipes-graphics/mesa/files/0004-Revert-mesa-Enable-asm-unconditionally-now-that-gen_.patch
+++ b/recipes-graphics/mesa/files/0004-Revert-mesa-Enable-asm-unconditionally-now-that-gen_.patch
@@ -1,4 +1,4 @@
-From b6477a1e7f1b7ba227721c89b612d8e3479bf541 Mon Sep 17 00:00:00 2001
+From 793a0a974e56b072699f8613978acc7d08b8857a Mon Sep 17 00:00:00 2001
 From: Alistair Francis <alistair@alistair23.me>
 Date: Wed, 2 Sep 2020 15:31:59 -0500
 Subject: [PATCH] Revert "mesa: Enable asm unconditionally, now that
@@ -37,10 +37,10 @@ index 7ef6a90a179..061de3bb147 100644
  ifeq ($(ARCH_ARM_HAVE_NEON),true)
  LOCAL_CFLAGS_arm += -DUSE_ARM_ASM
 diff --git a/Android.mk b/Android.mk
-index 07eba7b8316..25c531cb61c 100644
+index 3b5d029f804..6ec64abc87c 100644
 --- a/Android.mk
 +++ b/Android.mk
-@@ -90,6 +90,13 @@ endif
+@@ -96,6 +96,13 @@ endif
  
  $(foreach d, $(MESA_BUILD_CLASSIC) $(MESA_BUILD_GALLIUM), $(eval $(d) := true))
  
@@ -55,10 +55,10 @@ index 07eba7b8316..25c531cb61c 100644
  MESA_ENABLE_LLVM := true
  endif
 diff --git a/meson.build b/meson.build
-index 077af8eed31..664ce66d6b0 100644
+index f19e59c32fe..69a01218792 100644
 --- a/meson.build
 +++ b/meson.build
-@@ -52,6 +52,9 @@ pre_args = [
+@@ -55,6 +55,9 @@ with_moltenvk_dir = get_option('moltenvk-dir')
  with_vulkan_icd_dir = get_option('vulkan-icd-dir')
  with_tests = get_option('build-tests')
  with_aco_tests = get_option('build-aco-tests')
@@ -68,7 +68,7 @@ index 077af8eed31..664ce66d6b0 100644
  with_glx_read_only_text = get_option('glx-read-only-text')
  with_glx_direct = get_option('glx-direct')
  with_osmesa = get_option('osmesa')
-@@ -1222,41 +1225,68 @@ dep_ws2_32 = cc.find_library('ws2_32', required : with_platform_windows)
+@@ -1236,41 +1239,68 @@ dep_ws2_32 = cc.find_library('ws2_32', required : with_platform_windows)
  
  # TODO: shared/static? Is this even worth doing?
  
@@ -171,10 +171,10 @@ index 077af8eed31..664ce66d6b0 100644
  endif
  
 diff --git a/meson_options.txt b/meson_options.txt
-index d9a6f808bc2..b83efcfe486 100644
+index f7354104c4a..648059478fc 100644
 --- a/meson_options.txt
 +++ b/meson_options.txt
-@@ -257,6 +257,12 @@ option(
+@@ -263,6 +263,12 @@ option(
    choices : ['auto', 'true', 'false', 'enabled', 'disabled'],
    description : 'Build support for OpenGL ES 2.x and 3.x'
  )

--- a/recipes-graphics/mesa/mesa_git.bb
+++ b/recipes-graphics/mesa/mesa_git.bb
@@ -28,7 +28,7 @@ FILES_${PN}-ci = "${bindir}/deqp-runner.sh ${datadir}/mesa/deqp-*"
 do_install_append () {
     install -d ${D}/${datadir}/mesa
 
-    install -m 0644 ${S}/.gitlab-ci/deqp-default-skips.txt ${D}/${datadir}/mesa/
+    install -m 0644 ${S}/.gitlab-ci/deqp-all-skips.txt ${D}/${datadir}/mesa/
     for f in ${S}/src/freedreno/ci/deqp-freedreno-*; do
         install -m 0644 $f ${D}/${datadir}/mesa/
     done


### PR DESCRIPTION
The deqp skips file was renamed, see,

https://gitlab.freedesktop.org/mesa/mesa/-/commit/9cc1f089196f2f5c695dbf5f42b947b9970b8965

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>