### PR TITLE
recipes-support: rmtfs bump to rev 293ab8b

### DIFF
--- a/recipes-support/rmtfs/rmtfs_git.bb
+++ b/recipes-support/rmtfs/rmtfs_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=ca25dbf5ebfc1a058bfc657c895aac2f"
 
 inherit systemd
 
-SRCREV = "1cc12d3dc1f251f6d3151970621a06fdd013a1d0"
+SRCREV = "293ab8babb27ac0f24247bb101fed9420c629c29"
 SRC_URI = "git://github.com/andersson/${BPN}.git;branch=master;protocol=https"
 DEPENDS = "qmic-native qrtr udev"
 


### PR DESCRIPTION
Change,

293ab8b storage: Sync changes

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>
(cherry picked from commit 1aaf336728b7e4de137e975d3a22cc5dafd8ed41)
Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>