### PR TITLE
conf/machine: Set default SERIAL_CONSOLES in qcom-common.inc

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -31,3 +31,6 @@ IMAGE_ROOTFS_ALIGNMENT ?= "4096"
 # Android boot image settings
 QCOM_BOOTIMG_KERNEL_BASE ?= "0x80000000"
 QCOM_BOOTIMG_PAGE_SIZE ?= "4096"
+
+# Default serial console for QCOM devices
+SERIAL_CONSOLES ?= "115200;ttyMSM0"


### PR DESCRIPTION
The SERIAL_CONSOLES var is used inside systemd-serialgetty.bb to
generate systemd unit to get console after boot, this fix no console in
DB845c.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>
(cherry picked from commit 40ae8d5b56422ef440b603d2e6713d8b577138ab)
Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>