### PR TITLE
linux-linaro-qcomlt_5.13.bb: Remove duplicate inclusion of linux-qcom…

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.13.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.13.bb
@@ -5,7 +5,6 @@ DESCRIPTION = "Linaro Qualcomm Landing team 5.13 Kernel"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 require recipes-kernel/linux/linux-linaro-qcom.inc
-require recipes-kernel/linux/linux-qcom-bootimg.inc
 
 LOCALVERSION ?= "-linaro-lt-qcom"
 


### PR DESCRIPTION
…-bootimg.inc

Fixes parse warning
linux-linaro-qcomlt_5.13.bb: Duplicate inclusion for
/mnt/b/yoe/master/sources/meta-qcom/recipes-kernel/linux/linux-qcom-bootimg.inc in /mnt/b/yoe/master/sources/meta-qcom/
recipes-kernel/linux/linux-linaro-qcomlt_5.13.bb

% git grep linux-qcom-bootimg.inc
recipes-kernel/linux/linux-linaro-qcom.inc:require recipes-kernel/linux/linux-qcom-bootimg.inc
recipes-kernel/linux/linux-linaro-qcomlt_5.13.bb:require recipes-kernel/linux/linux-qcom-bootimg.inc

Signed-off-by: Khem Raj <raj.khem@gmail.com>