### PR TITLE
linux-linaro-qcom: update LOCALVERSION

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcom.inc
+++ b/recipes-kernel/linux/linux-linaro-qcom.inc
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 inherit kernel
 
-LOCALVERSION ?= "+linaro"
+LOCALVERSION ?= "-linaro-lt-qcom"
 SCMVERSION ?= "y"
 
 SRCBRANCH = "release/qcomlt-${PV}"


### PR DESCRIPTION
Fixes: 7829b0f0f691 (linux-linaro-qcomlt: move common settings to the
include file)

In this commit, some common config were moved into the shared include
file, however LOCALVERSION was not updated based on its value in the
kernel recipe. Restore LOCALVERSION to what it was before this patch.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>