### PR TITLE
linux-linaro-qcomlt_5.13: remove default configs

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.13.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.13.bb
@@ -1,14 +1,6 @@
 # Copyright (C) 2014-2020 Linaro
 # Released under the MIT license (see COPYING.MIT for the terms)
 
-DESCRIPTION = "Linaro Qualcomm Landing team 5.13 Kernel"
-LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
-
 require recipes-kernel/linux/linux-linaro-qcom.inc
 
-LOCALVERSION ?= "-linaro-lt-qcom"
-
-SRCBRANCH = "release/qcomlt-5.13"
 SRCREV = "108d71930dc8a8c10036ed0acd70e9ed3d7d1675"
-
-COMPATIBLE_MACHINE = "(qcom)"


### PR DESCRIPTION
Default configuration have been moved in the shared include file,
since 7829b0f0f691 (linux-linaro-qcomlt: move common settings to the
include file), so there is no need to repeat them in each new kernel
recipe.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>