### PR TITLE
recipes-kernel: Linux 5.13 bump to rev 9095a563c16e (v5.13.6)

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.13.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.13.bb
@@ -3,4 +3,4 @@
 
 require recipes-kernel/linux/linux-linaro-qcom.inc
 
-SRCREV = "108d71930dc8a8c10036ed0acd70e9ed3d7d1675"
+SRCREV = "9095a563c16edb89d00f162fee4df405b4f003a6"


### PR DESCRIPTION
Changes are from stable v5.13.5..v5.13.6.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>