### PR TITLE
layer: convert to new override syntax

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PATTERN_qcom := "^${LAYERDIR}/"
 BBFILE_PRIORITY_qcom = "5"
 
 LAYERDEPENDS_qcom = "core"
-LAYERSERIES_COMPAT_qcom = "zeus dunfell gatesgarth hardknott"
+LAYERSERIES_COMPAT_qcom = "honister"
 
 BBFILES_DYNAMIC += " \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bb \

--- a/conf/machine/dragonboard-410c-32.conf
+++ b/conf/machine/dragonboard-410c-32.conf
@@ -11,7 +11,7 @@ SERIAL_CONSOLE ?= "115200 ttyMSM0"
 
 # Building 32-bit kernel is not supported.
 PREFERRED_PROVIDER_virtual/kernel = "linux-dummy"
-RDEPENDS_kernel-base = ""
+RDEPENDS:kernel-base = ""
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \

--- a/conf/machine/dragonboard-820c.conf
+++ b/conf/machine/dragonboard-820c.conf
@@ -25,4 +25,4 @@ QCOM_BOOTIMG_ROOTFS ?= "/dev/sda1"
 UBOOT_MACHINE ?= "dragonboard820c_defconfig"
 
 # UFS partitions setup with 4096 logical sector size
-EXTRA_IMAGECMD_ext4 += " -b 4096 "
+EXTRA_IMAGECMD:ext4 += " -b 4096 "

--- a/conf/machine/dragonboard-845c.conf
+++ b/conf/machine/dragonboard-845c.conf
@@ -27,4 +27,4 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 QCOM_BOOTIMG_ROOTFS ?= "/dev/sda1"
 
 # UFS partitions setup with 4096 logical sector size
-EXTRA_IMAGECMD_ext4 += " -b 4096 "
+EXTRA_IMAGECMD:ext4 += " -b 4096 "

--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -1,4 +1,4 @@
-SOC_FAMILY_prepend = "qcom:"
+SOC_FAMILY:prepend = "qcom:"
 require conf/machine/include/soc-family.inc
 
 XSERVER_OPENGL ?= " \

--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -4,7 +4,7 @@ require conf/machine/include/arm/arch-armv8a.inc
 MACHINE_FEATURES = "usbhost usbgadget alsa screen wifi bluetooth ext2"
 
 # UFS partitions in 820/845/RB5 setup with 4096 logical sector size
-EXTRA_IMAGECMD_ext4 += " -b 4096 "
+EXTRA_IMAGECMD:ext4 += " -b 4096 "
 
 # Support for dragonboard{410, 820, 845}c, rb5
 KERNEL_IMAGETYPE ?= "Image.gz"

--- a/conf/machine/qrb5165-rb5.conf
+++ b/conf/machine/qrb5165-rb5.conf
@@ -25,4 +25,4 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 QCOM_BOOTIMG_ROOTFS ?= "/dev/sda1"
 
 # UFS partitions setup with 4096 logical sector size
-EXTRA_IMAGECMD_ext4 += " -b 4096 "
+EXTRA_IMAGECMD:ext4 += " -b 4096 "

--- a/conf/machine/sm8250-mtp.conf
+++ b/conf/machine/sm8250-mtp.conf
@@ -22,4 +22,4 @@ MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
 QCOM_BOOTIMG_ROOTFS ?= "/dev/sda15"
 
 # UFS partitions setup with 4096 logical sector size
-EXTRA_IMAGECMD_ext4 += " -b 4096 "
+EXTRA_IMAGECMD:ext4 += " -b 4096 "

--- a/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf-configfs_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-conf-configfs_%.bbappend
@@ -1,5 +1,5 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
-SRC_URI_append_qcom = " \
+SRC_URI:append:qcom = " \
     file://android-gadget-setup.machine \
 "

--- a/dynamic-layers/openembedded-layer/recipes-navigation/gpsd/gpsd_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-navigation/gpsd/gpsd_%.bbappend
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 SRC_URI += " \
     file://0001-Introduce-Qualcomm-PDS-service-support.patch \

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard410c.inc
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard410c.inc
@@ -29,8 +29,8 @@ do_install() {
     install -m 0644 LICENSE ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE-${PN}
 }
 
-FILES_${PN} += "/boot/modem_fsg"
-FILES_${PN} += "${nonarch_base_libdir}/firmware/wlan/*"
-FILES_${PN} += "${nonarch_base_libdir}/firmware/qcom/msm8916/*"
+FILES:${PN} += "/boot/modem_fsg"
+FILES:${PN} += "${nonarch_base_libdir}/firmware/wlan/*"
+FILES:${PN} += "${nonarch_base_libdir}/firmware/qcom/msm8916/*"
 
-INSANE_SKIP_${PN} += "arch"
+INSANE_SKIP:${PN} += "arch"

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard820c_01700.1.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard820c_01700.1.bb
@@ -27,5 +27,5 @@ do_install() {
     install -m 0644 LICENSE ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE-${PN}
 }
 
-FILES_${PN} += "${nonarch_base_libdir}/firmware/*"
-INSANE_SKIP_${PN} += "arch"
+FILES:${PN} += "${nonarch_base_libdir}/firmware/*"
+INSANE_SKIP:${PN} += "arch"

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
@@ -35,5 +35,5 @@ do_install() {
     install -m 0644 LICENSE.qcom.txt ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE-${PN}
 }
 
-FILES_${PN} += "${nonarch_base_libdir}/firmware/*"
-INSANE_SKIP_${PN} += "arch"
+FILES:${PN} += "${nonarch_base_libdir}/firmware/*"
+INSANE_SKIP:${PN} += "arch"

--- a/recipes-bsp/firmware/firmware-qcom-rb5_20210331-v4.bb
+++ b/recipes-bsp/firmware/firmware-qcom-rb5_20210331-v4.bb
@@ -57,22 +57,22 @@ do_install() {
     install -m 0644 LICENSE.qcom.txt ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE-${PN}
 }
 
-FILES_${PN} += "${nonarch_base_libdir}/firmware/"
-INSANE_SKIP_${PN} += "arch"
+FILES:${PN} += "${nonarch_base_libdir}/firmware/"
+INSANE_SKIP:${PN} += "arch"
 INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 INHIBIT_PACKAGE_STRIP = "1"
 INHIBIT_DEFAULT_DEPS = "1"
 
-RPROVIDES_${PN} += "linux-firmware-qcom-adreno-a650"
-RREPLACES_${PN} += "linux-firmware-qcom-adreno-a650"
-RCONFLICTS_${PN} += "linux-firmware-qcom-adreno-a650"
+RPROVIDES:${PN} += "linux-firmware-qcom-adreno-a650"
+RREPLACES:${PN} += "linux-firmware-qcom-adreno-a650"
+RCONFLICTS:${PN} += "linux-firmware-qcom-adreno-a650"
 
-RPROVIDES_${PN} += "linux-firmware-qcom-${VENUS_FW}"
-RREPLACES_${PN} += "linux-firmware-qcom-${VENUS_FW}"
-RCONFLICTS_${PN} += "linux-firmware-qcom-${VENUS_FW}"
+RPROVIDES:${PN} += "linux-firmware-qcom-${VENUS_FW}"
+RREPLACES:${PN} += "linux-firmware-qcom-${VENUS_FW}"
+RCONFLICTS:${PN} += "linux-firmware-qcom-${VENUS_FW}"
 
 inherit update-alternatives
 
-ALTERNATIVE_${PN} = "qca6390-board2"
+ALTERNATIVE:${PN} = "qca6390-board2"
 ALTERNATIVE_LINK_NAME[qca6390-board2] = "/lib/firmware/ath11k/QCA6390/hw2.0/board-2.bin"
 ALTERNATIVE_PRIORITY = "100"

--- a/recipes-bsp/firmware/firmware-qcom-sd-600eval_1.0.bb
+++ b/recipes-bsp/firmware/firmware-qcom-sd-600eval_1.0.bb
@@ -23,5 +23,5 @@ do_install() {
     install -m 0644 license.txt ${D}${sysconfdir}/
 }
 
-FILES_${PN} += "${nonarch_base_libdir}/firmware/*"
-INSANE_SKIP_${PN} += "arch already-stripped"
+FILES:${PN} += "${nonarch_base_libdir}/firmware/*"
+INSANE_SKIP:${PN} += "arch already-stripped"

--- a/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife_git.bb
+++ b/recipes-devtools/qca-swiss-army-knife/qca-swiss-army-knife_git.bb
@@ -29,4 +29,4 @@ do_install () {
 
 BBCLASSEXTEND = "native nativesdk"
 
-RDEPENDS_${PN} += "perl python3-core"
+RDEPENDS:${PN} += "perl python3-core"

--- a/recipes-devtools/qdl/qdl_git.bb
+++ b/recipes-devtools/qdl/qdl_git.bb
@@ -6,7 +6,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://qdl.c;beginline=1;endline=31;md5=1c7d712d897368d3d3c161e5493efc6a"
 
 DEPENDS = "libxml2"
-DEPENDS_append_class-target = " udev "
+DEPENDS:append:class-target = " udev "
 
 inherit pkgconfig
 

--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -1,4 +1,4 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${BPN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 
 # Enable freedreno driver
 PACKAGECONFIG_FREEDRENO = "\
@@ -6,4 +6,4 @@ PACKAGECONFIG_FREEDRENO = "\
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'xa', '', d)} \
 "
 
-PACKAGECONFIG_append_qcom = "${PACKAGECONFIG_FREEDRENO}"
+PACKAGECONFIG:append:qcom = "${PACKAGECONFIG_FREEDRENO}"

--- a/recipes-graphics/mesa/mesa_git.bb
+++ b/recipes-graphics/mesa/mesa_git.bb
@@ -10,20 +10,20 @@ LIC_FILES_CHKSUM = "file://docs/license.rst;md5=17a4ea65de7a9ab42437f3131e616a7f
 SRCREV = "${@oe.utils.conditional("MESA_DEV", "1", "${AUTOREV}", "26677008b9a7c0ef82f2a7f4b479d3cb06097c66", d)}"
 DEFAULT_PREFERENCE = "${@oe.utils.conditional("MESA_DEV", "1", "1", "-1", d)}"
 
-PLATFORMS_remove = "drm surfaceless"
+PLATFORMS:remove = "drm surfaceless"
 PACKAGECONFIG[osmesa] = "-Dosmesa=true,-Dosmesa=false"
-DRIDRIVERS_remove = "swrast"
-DRIDRIVERS_class-native = "auto"
-DRIDRIVERS_class-nativesdk = "auto"
+DRIDRIVERS:remove = "swrast"
+DRIDRIVERS:class-native = "auto"
+DRIDRIVERS:class-nativesdk = "auto"
 
 S = "${WORKDIR}/git"
 PV = "2x.x-dev+git${SRCPV}"
-ERROR_QA_remove = "version-going-backwards"
+ERROR_QA:remove = "version-going-backwards"
 
 # Add package to install require files to run tests for mesa
 PACKAGES =+ "mesa-ci"
-FILES_${PN}-ci = "${bindir}/deqp-runner.sh ${datadir}/mesa/deqp-*"
-do_install_append () {
+FILES:${PN}-ci = "${bindir}/deqp-runner.sh ${datadir}/mesa/deqp-*"
+do_install:append () {
     install -d ${D}/${datadir}/mesa
 
     install -m 0644 ${S}/.gitlab-ci/deqp-all-skips.txt ${D}/${datadir}/mesa/

--- a/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xf86-config_0.1.bbappend
@@ -1,1 +1,1 @@
-FILESEXTRAPATHS_prepend := "${THISDIR}/${PN}:"
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"

--- a/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
+++ b/recipes-graphics/xorg-xserver/xserver-xorg_%.bbappend
@@ -1,3 +1,3 @@
 # We want to use modesetting + glamor with mesa freedreno driver
 # http://bloggingthemonkey.blogspot.fr/2016/11/a-quick-note-for-usersdistros.html
-PACKAGECONFIG_append_qcom = "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', ' dri3 xshmfence glamor', '', d)}"
+PACKAGECONFIG:append:qcom = "${@bb.utils.contains('DISTRO_FEATURES', 'opengl', ' dri3 xshmfence glamor', '', d)}"

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,4 +1,4 @@
 inherit update-alternatives
 
-ALTERNATIVE_${PN}-ath11k = "qca6390-board2"
+ALTERNATIVE:${PN}-ath11k = "qca6390-board2"
 ALTERNATIVE_LINK_NAME[qca6390-board2] = "/lib/firmware/ath11k/QCA6390/hw2.0/board-2.bin"

--- a/recipes-kernel/linux/linux-linaro-qcom.inc
+++ b/recipes-kernel/linux/linux-linaro-qcom.inc
@@ -20,8 +20,8 @@ SRC_URI = "${LINUX_LINARO_QCOM_GIT};branch=${SRCBRANCH}"
 
 S = "${WORKDIR}/git"
 
-KERNEL_DEFCONFIG_aarch64 ?= "${S}/arch/arm64/configs/defconfig"
-KERNEL_DEFCONFIG_arm ?= "${S}/arch/arm/configs/qcom_defconfig"
+KERNEL_DEFCONFIG:aarch64 ?= "${S}/arch/arm64/configs/defconfig"
+KERNEL_DEFCONFIG:arm ?= "${S}/arch/arm/configs/qcom_defconfig"
 KERNEL_CONFIG_FRAGMENTS += "${S}/kernel/configs/distro.config"
 
 require recipes-kernel/linux/linux-qcom-bootimg.inc
@@ -36,7 +36,7 @@ kernel_conf_variable() {
 	fi
 }
 
-do_configure_prepend() {
+do_configure:prepend() {
 	if [ -f '${WORKDIR}/defconfig' ]; then
 		cp '${WORKDIR}/defconfig' '${B}/.config'
 	else
@@ -81,6 +81,6 @@ do_configure_prepend() {
     fi
 }
 
-do_configure_append() {
+do_configure:append() {
         oe_runmake -C ${S} O=${B} savedefconfig && cp ${B}/defconfig ${WORKDIR}/defconfig.saved
 }

--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.7.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.7.bb
@@ -5,7 +5,7 @@ require recipes-kernel/linux/linux-linaro-qcom.inc
 
 inherit python3native
 
-SRC_URI_append_qrb5165-rb5 = " \
+SRC_URI:append:qrb5165-rb5 = " \
     file://qrb5165-rb5.dts;subdir=git/arch/arm64/boot/dts/qcom \
     file://qrb5165-rb5-enable.patch \
     file://0001-arm64-dts-qcom-sm8250-change-spmi-node-label.patch \

--- a/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -1,3 +1,3 @@
-do_install_append() {
+do_install:append() {
 	sed -i "s|^load-module module-udev-detect|load-module module-udev-detect tsched=0|" ${D}${sysconfdir}/pulse/default.pa
 }

--- a/recipes-support/fastrpc/fastrpc_git.bb
+++ b/recipes-support/fastrpc/fastrpc_git.bb
@@ -22,16 +22,16 @@ S = "${WORKDIR}/git"
 inherit autotools systemd
 
 PACKAGES += "${PN}-systemd"
-RRECOMMENDS_${PN} += "${PN}-systemd"
+RRECOMMENDS:${PN} += "${PN}-systemd"
 
 SYSTEMD_PACKAGES = "${PN} ${PN}-systemd"
 
-SYSTEMD_SERVICE_${PN} = "usr-lib-rfsa.service"
+SYSTEMD_SERVICE:${PN} = "usr-lib-rfsa.service"
 
-SYSTEMD_SERVICE_${PN}-systemd = "adsprpcd.service cdsprpcd.service"
-SYSTEMD_AUTO_ENABLE_${PN}-systemd = "disable"
+SYSTEMD_SERVICE:${PN}-systemd = "adsprpcd.service cdsprpcd.service"
+SYSTEMD_AUTO_ENABLE:${PN}-systemd = "disable"
 
-do_install_append() {
+do_install:append() {
     install -d ${D}${libdir}/rfsa
 
     install -d ${D}${systemd_unitdir}/system
@@ -43,7 +43,7 @@ do_install_append() {
     install -m 0755 ${WORKDIR}/mount-dsp.sh ${D}${sbindir}
 }
 
-FILES_${PN} += " \
+FILES:${PN} += " \
     ${libdir}/rfsa \
     ${libdir}/libadsp_default_listener.so \
     ${libdir}/libcdsp_default_listener.so \
@@ -51,7 +51,7 @@ FILES_${PN} += " \
     ${libdir}/libcdsprpc.so \
 "
 
-FILES_${PN}-dev_remove = "${FILES_SOLIBSDEV}"
+FILES:${PN}-dev:remove = "${FILES_SOLIBSDEV}"
 
 # We need to include lib*dsprpc.so into fastrpc for compatibility with Hexagon SDK
-ERROR_QA_remove = "dev-so"
+ERROR_QA:remove = "dev-so"

--- a/recipes-support/pd-mapper/pd-mapper_git.bb
+++ b/recipes-support/pd-mapper/pd-mapper_git.bb
@@ -23,5 +23,5 @@ do_install () {
     oe_runmake install DESTDIR=${D} prefix=${prefix} servicedir=${systemd_unitdir}/system
 }
 
-SYSTEMD_SERVICE_${PN} = "pd-mapper.service"
-RDEPENDS_${PN} += "qrtr"
+SYSTEMD_SERVICE:${PN} = "pd-mapper.service"
+RDEPENDS:${PN} += "qrtr"

--- a/recipes-support/qrtr/qrtr_git.bb
+++ b/recipes-support/qrtr/qrtr_git.bb
@@ -20,4 +20,4 @@ do_install () {
     oe_runmake install DESTDIR=${D} prefix=${prefix} servicedir=${systemd_unitdir}/system
 }
 
-SYSTEMD_SERVICE_${PN} = "qrtr-ns.service"
+SYSTEMD_SERVICE:${PN} = "qrtr-ns.service"

--- a/recipes-support/rmtfs/rmtfs_git.bb
+++ b/recipes-support/rmtfs/rmtfs_git.bb
@@ -21,5 +21,5 @@ do_install () {
     oe_runmake install DESTDIR=${D} prefix=${prefix} servicedir=${systemd_unitdir}/system
 }
 
-SYSTEMD_SERVICE_${PN} = "rmtfs.service"
-RDEPENDS_${PN} += "qrtr"
+SYSTEMD_SERVICE:${PN} = "rmtfs.service"
+RDEPENDS:${PN} += "qrtr"

--- a/recipes-support/tqftpserv/tqftpserv_git.bb
+++ b/recipes-support/tqftpserv/tqftpserv_git.bb
@@ -24,5 +24,5 @@ do_install () {
     oe_runmake install DESTDIR=${D} prefix=${prefix} servicedir=${systemd_unitdir}/system
 }
 
-SYSTEMD_SERVICE_${PN} = "tqftpserv.service"
-RDEPENDS_${PN} += "qrtr"
+SYSTEMD_SERVICE:${PN} = "tqftpserv.service"
+RDEPENDS:${PN} += "qrtr"


### PR DESCRIPTION
The conversion was mostly automated with:
./scripts/contrib/convert-overrides.py

With a few manual tweaks.

Also change LAYERCOMPAT to honister.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>