### PR TITLE
recipes-kernel: Linux 5.13 bump to rev 473ca0b26c31 (v5.13.9)

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.13.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.13.bb
@@ -3,4 +3,4 @@
 
 require recipes-kernel/linux/linux-linaro-qcom.inc
 
-SRCREV = "9095a563c16edb89d00f162fee4df405b4f003a6"
+SRCREV = "473ca0b26c313e450dbcbfe1bcde238356aeb8f2"


### PR DESCRIPTION
Changes are from stable v5.13.6..v5.13.9.

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>