### PR TITLE
linux-linaro-qcomlt: bump SRCREV to include more fixes

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.13.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.13.bb
@@ -3,4 +3,4 @@
 
 require recipes-kernel/linux/linux-linaro-qcom.inc
 
-SRCREV = "473ca0b26c313e450dbcbfe1bcde238356aeb8f2"
+SRCREV = "7644c86e7429a8766ac8ac2b9b518807207406bb"


### PR DESCRIPTION
Apply several more fixes including the one to fix USB gadget support on
RB5.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
(cherry picked from commit 1ddc4012bf21d5c2160d029a551aab5fff5b9f57)