### PR TITLE
recipes-kernel: Linux 5.13 bump to rev 1429722a2209

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.13.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.13.bb
@@ -3,4 +3,4 @@
 
 require recipes-kernel/linux/linux-linaro-qcom.inc
 
-SRCREV = "473ca0b26c313e450dbcbfe1bcde238356aeb8f2"
+SRCREV = "1429722a220973e881d8cb5b5b486693457b4f11"


### PR DESCRIPTION
Summary,

- Update LHM patches for RB3 because old ones causes crash when use
  hackbench.
- Remove enablement of TYPEC_MUX_NB7VPQ904M not used in RB5 atm.

Changes,

1429722a2209 dt-bindings: thermal: Add dt binding for QCOM LMh
e59d36510fc7 arm64: dts: qcom: sdm845: Remove cpufreq cooling devices for CPU thermal zones
5313a150780d arm64: dts: qcom: sdm45: Add support for LMh node
0cdd72ea4ded cpufreq: qcom-cpufreq-hw: Add dcvs interrupt support
28c75f036f17 thermal: qcom: Add support for LMh driver
5249d7424534 firmware: qcom_scm: Introduce SCM calls to access LMh
79a4f0126f44 Revert "arm64: defconfig: Enable TYPEC_MUX_NB7VPQ904M for RB5"
d56d5568e63c Revert "dt-bindings: thermal: Add dt binding for QCOM LMh"
832f6e4b8290 Revert "arm64: boot: dts: qcom: sdm845: Remove cpufreq cooling devices for CPU thermal zones"
a185df1e18f0 Revert "arm64: boot: dts: qcom: sdm45: Add support for LMh node"
5812252ae05e Revert "cpufreq: qcom-cpufreq-hw: Add dcvs interrupt support"
0efdda131645 Revert "thermal: qcom: Add support for LMh driver"
caf368b9c84d Revert "firmware: qcom_scm: Introduce SCM calls to access LMh"
1ca791917067 arm64: defconfig: Enable TYPEC_MUX_NB7VPQ904M for RB5

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>
(cherry picked from commit 1eb33541f4e2921457d8416152d484174484b55e)