### PR TITLE
gpsd-machine-conf: provide gpsd config for qcom machines

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-navigation/gpsd/gpsd-machine-conf/gpsd.pds
+++ b/dynamic-layers/openembedded-layer/recipes-navigation/gpsd/gpsd-machine-conf/gpsd.pds
@@ -1,0 +1,5 @@
+START_DAEMON="true"
+GPSD_OPTIONS=""
+DEVICES="pds://0"
+USBAUTO="true"
+GPSD_SOCKET="/var/run/gpsd.sock"

--- a/dynamic-layers/openembedded-layer/recipes-navigation/gpsd/gpsd-machine-conf_%.bbappend
+++ b/dynamic-layers/openembedded-layer/recipes-navigation/gpsd/gpsd-machine-conf_%.bbappend
@@ -1,0 +1,19 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+SRC_URI = " \
+           file://gpsd.pds \
+"
+
+inherit update-alternatives
+
+ALTERNATIVE:${PN} = "gpsd-defaults"
+ALTERNATIVE_LINK_NAME[gpsd-defaults] = "${sysconfdir}/default/gpsd"
+ALTERNATIVE_TARGET[gpsd-defaults] = "${sysconfdir}/default/gpsd.pds"
+ALTERNATIVE_PRIORITY[gpsd-defaults] = "15"
+
+do_install:append:qcom() {
+    install -d ${D}/${sysconfdir}/default
+    install -m 0644 ${WORKDIR}/gpsd.pds ${D}/${sysconfdir}/default/
+}
+
+FILES:${PN} = "${sysconfdir}"


### PR DESCRIPTION
Provide gpsd config adding pds:// devices.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>