### PR TITLE
conf/sa8155p-adp: Add kernel-modules

### DIFF
--- a/conf/machine/sa8155p-adp.conf
+++ b/conf/machine/sa8155p-adp.conf
@@ -11,6 +11,10 @@ KERNEL_DEVICETREE ?= "qcom/sa8155p-adp.dtb"
 
 SERIAL_CONSOLE ?= "115200 ttyMSM0"
 
+MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
+    kernel-modules \
+"
+
 # /dev/sda6 is 'userdata' partition for adp board, so wipe it and use for our build
 QCOM_BOOTIMG_ROOTFS ?= "/dev/sda6"
 


### PR DESCRIPTION
Add the missing 'MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS'
directive in sa8155p-adp.conf

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>