### PR TITLE
layer.conf: set INITRAMFS_IMAGE for sa8155p machine

### DIFF
--- a/conf/machine/sa8155p-adp.conf
+++ b/conf/machine/sa8155p-adp.conf
@@ -4,6 +4,9 @@
 
 require conf/machine/include/qcom-sa8155p.inc
 
+# Set INITRAMFS_IMAGE for sa8155p machine
+INITRAMFS_IMAGE = "initramfs-kerneltest-full-image"
+
 MACHINE_FEATURES = "usbhost usbgadget ext2"
 
 KERNEL_IMAGETYPE ?= "Image.gz"


### PR DESCRIPTION
Set INITRAMFS_IMAGE as "initramfs-kerneltest-full-image"
for sa8155p machine .

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>