### PR TITLE
initramfs-test-full: Add more utils

### DIFF
--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -15,7 +15,8 @@ PACKAGE_INSTALL += " \
     ethtool \
     gptfdisk \
     iw \
-    kexec-tools \
+    hdparm \
+    kexec \
     lava-test-shell \
     libdrm-tests \
     lsof \
@@ -45,10 +46,17 @@ PACKAGE_INSTALL_openembedded_layer += " \
     crash \
     cryptsetup \
     devmem2 \
+    dhrystone \
     iozone3 \
     libgpiod \
     libgpiod-tools \
+    lmbench \
     makedumpfile \
+    mbw \
+    sysbench \
+    tinymembench \
+    tiobench \
+    whetstone \
 "
 
 PACKAGE_INSTALL_networking_layer += " \


### PR DESCRIPTION
Add the following utilities in 'initramfs-test-full-image.bb'

- hdparm (for performance checks - e.g. USB mass storage related)
- mbw, dhrystone, lmbench, sysbench, tinymembench, tiobench, whetstone
  (for performance checks).
- Add kexec instead of the complete 'kexec-tools'

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>