### PR TITLE
Add bootrr to meta qcom

### DIFF
--- a/recipes-test/bootrr/bootrr/bootrr-auto-switch-to-using-sh.patch
+++ b/recipes-test/bootrr/bootrr/bootrr-auto-switch-to-using-sh.patch
@@ -1,0 +1,22 @@
+From ef8073c29988c1cf46221e3062811f19e051b62d Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Sat, 2 Oct 2021 16:36:47 +0300
+Subject: [PATCH] bootrr-auto: switch to using sh
+
+There is nothing bash-specific in bootrr-auto, we can safely use /bin/sh
+instead. Verified with dash and with busybox sh.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+---
+ helpers/bootrr-auto | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/helpers/bootrr-auto b/helpers/bootrr-auto
+index 672c590..607be0a 100755
+--- a/helpers/bootrr-auto
++++ b/helpers/bootrr-auto
+@@ -1,4 +1,4 @@
+-#!/bin/bash
++#!/bin/sh
+ 
+ $(pwd)/helpers/bootrr-generic-tests

--- a/recipes-test/bootrr/bootrr_git.bb
+++ b/recipes-test/bootrr/bootrr_git.bb
@@ -1,0 +1,16 @@
+SUMMARY = "simple low-level testing tool for qcom boards"
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=987293312a134ab40eec5f3d446cfaff"
+
+SRCREV = "d2329902b701e0efa345628471d0d275d5a5835a"
+SRC_URI = "\
+	git://github.com/andersson/bootrr.git \
+	file://bootrr-auto-switch-to-using-sh.patch \
+"
+
+S = "${WORKDIR}/git"
+
+do_install() {
+	oe_runmake install 'DESTDIR=${D}'
+}

--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -4,6 +4,7 @@ DESCRIPTION = "Relatively larger ramdisk image for running tests (bootrr, etc)"
 
 PACKAGE_INSTALL += " \
     bluez5 \
+    bootrr \
     coreutils \
     dhcpcd \
     diag \


### PR DESCRIPTION
This is a RFC patch which allows adding bootrr to the meta-qcom layer as a receipes-test component.
To do:
- I am using my github tree as the SRC_UI, instead of Bjorn's official tree as PR raised against the bootrr tree is still under review <https://github.com/andersson/bootrr/pull/38>
- SRCBRANCH, etc should also be changed in the final version of this patch to point to the 'bootrr/master' branch.

I tested the resulting bootrr board helper files on sm8150-mtp and sa8155-adp boards with this change by running them as-

# qcom,sm8150-mtp
