### PR TITLE
firmware-qcom-rb5: remove obsolete comment

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-rb5_20210331-v4.bb
+++ b/recipes-bsp/firmware/firmware-qcom-rb5_20210331-v4.bb
@@ -1,9 +1,3 @@
-# Provide base URI of NHLOS_Binaries.zip and adreno_1.0_qrb5165_rb5.tar.gz
-# files.  Use "file://" if those files are copied into
-# recipes-bsp/firmware/files/ directory.
-# NHLOS_URI ?= "file://"
-# ADRENO_URI ?= "file://"
-
 DESCRIPTION = "QCOM Firmware for Qualcomm Robotics RB5 platform"
 
 LICENSE = "Proprietary"


### PR DESCRIPTION
Remove obsolete comment mentioning NHLOS_URI and ADRENO_URI.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>