### PR TITLE
initramfs-test-full: Add util-linux-lsblk

### DIFF
--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -32,6 +32,7 @@ PACKAGE_INSTALL += " \
     usbutils \
     util-linux \
     util-linux-chrt \
+    util-linux-lsblk \
     wpa-supplicant \
 "
 


### PR DESCRIPTION
Add 'util-linux-lsblk' in 'initramfs-test-full-image.bb',
which provides 'lsblk' utility.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>