### PR TITLE
initramfs-test-full: Add 'fastrpc' and 'remoteproc' capabilities

### DIFF
--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -13,6 +13,8 @@ PACKAGE_INSTALL += " \
     e2fsprogs-resize2fs \
     e2fsprogs-tune2fs \
     ethtool \
+    fastrpc \
+    firmware-qcom-${MACHINE} \
     gptfdisk \
     iw \
     hdparm \


### PR DESCRIPTION
Add 'fastrpc' and 'remoteproc' support in
'initramfs-test-full-image.bb', which provides
support for aDSP, cDSP and sDSP FW loading
and systemd service spawing for the same.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>