### PR TITLE
Per-board firmware packagegroups

### DIFF
--- a/conf/machine/dragonboard-410c-32.conf
+++ b/conf/machine/dragonboard-410c-32.conf
@@ -16,5 +16,5 @@ RDEPENDS:kernel-base = ""
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluez5', 'bluez5-noinst-tools', '', d)} \
-    firmware-qcom-dragonboard410c \
+    packagegroup-firmware-dragonboard410c \
 "

--- a/conf/machine/dragonboard-410c.conf
+++ b/conf/machine/dragonboard-410c.conf
@@ -14,10 +14,9 @@ SERIAL_CONSOLE ?= "115200 ttyMSM0"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     kernel-modules \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a3xx mesa-driver-msm', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluez5', 'bluez5-noinst-tools', '', d)} \
-    firmware-qcom-dragonboard410c \
-    linux-firmware-qcom-venus-1.8 \
+    packagegroup-firmware-dragonboard410c \
 "
 
 QCOM_BOOTIMG_ROOTFS ?= "/dev/mmcblk0p14"

--- a/conf/machine/dragonboard-820c.conf
+++ b/conf/machine/dragonboard-820c.conf
@@ -12,12 +12,9 @@ KERNEL_DEVICETREE ?= "qcom/apq8096-db820c.dtb"
 SERIAL_CONSOLE ?= "115200 ttyMSM0"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
-    firmware-qcom-dragonboard820c \
     kernel-modules \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a530 mesa-driver-msm', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
-    linux-firmware-qcom-venus-4.2 \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \
+    packagegroup-firmware-dragonboard820c \
 "
 
 QCOM_BOOTIMG_ROOTFS ?= "/dev/sda1"

--- a/conf/machine/dragonboard-845c.conf
+++ b/conf/machine/dragonboard-845c.conf
@@ -13,14 +13,9 @@ KERNEL_CMDLINE_EXTRA ?= "clk_ignore_unused pd_ignore_unused"
 SERIAL_CONSOLE ?= "115200 ttyMSM0"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
-    firmware-qcom-dragonboard845c \
     kernel-modules \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k linux-firmware-qcom-sdm845-modem', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca linux-firmware-qcom-sdm845-modem', '', d)} \
-    linux-firmware-qcom-sdm845-audio \
-    linux-firmware-qcom-sdm845-compute \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630 mesa-driver-msm', '', d)} \
-    linux-firmware-qcom-venus-5.2 \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \
+    packagegroup-firmware-dragonboard845c \
 "
 
 # /dev/sda1 is 'rootfs' partition after installing the latest bootloader package from linaro

--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -32,19 +32,10 @@ MACHINE_EXTRA_RRECOMMENDS += " \
 # Modules and firmware for all supported machines
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     kernel-modules \
-    firmware-qcom-dragonboard410c \
-    firmware-qcom-dragonboard820c \
-    firmware-qcom-dragonboard845c \
-    firmware-qcom-rb5 \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k linux-firmware-ath11k linux-firmware-qcom-sdm845-modem wireless-regdb-static', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca linux-firmware-qcom-sdm845-modem', '', d)} \
-    linux-firmware-qcom-sdm845-audio \
-    linux-firmware-qcom-sdm845-compute \
-    linux-firmware-qcom-sm8250-audio \
-    linux-firmware-qcom-sm8250-compute \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a3xx linux-firmware-qcom-adreno-a530 linux-firmware-qcom-adreno-a630 linux-firmware-qcom-adreno-a650', '', d)} \
-    linux-firmware-qcom-venus-1.8 \
-    linux-firmware-qcom-venus-4.2 \
-    linux-firmware-qcom-venus-5.2 \
-    linux-firmware-qcom-vpu-1.0 \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'wireless-regdb-static', '', d)} \
+    packagegroup-firmware-dragonboard410c \
+    packagegroup-firmware-dragonboard820c \
+    packagegroup-firmware-dragonboard845c \
+    packagegroup-firmware-rb5 \
 "

--- a/conf/machine/qrb5165-rb5.conf
+++ b/conf/machine/qrb5165-rb5.conf
@@ -14,13 +14,9 @@ SERIAL_CONSOLE ?= "115200 ttyMSM0"
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
     kernel-modules \
-    firmware-qcom-rb5 linux-firmware-lt9611uxc \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k wireless-regdb-static', '', d)} \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
-    linux-firmware-qcom-sm8250-audio \
-    linux-firmware-qcom-sm8250-compute \
-    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a650 mesa-driver-msm', '', d)} \
-    linux-firmware-qcom-vpu-1.0 \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'mesa-driver-msm', '', d)} \
+    packagegroup-firmware-rb5 \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'wireless-regdb-static', '', d)} \
 "
 
 # /dev/sda1 is 'rootfs' partition after installing the latest bootloader package from linaro

--- a/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard410c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard410c.bb
@@ -1,0 +1,9 @@
+SUMMARY = "Firmware packages for the DragonBoard 410c board"
+
+inherit packagegroup
+
+RRECOMMENDS:${PN} += " \
+    firmware-qcom-dragonboard410c \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a3xx', '', d)} \
+    linux-firmware-qcom-venus-1.8 \
+"

--- a/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard820c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard820c.bb
@@ -1,0 +1,11 @@
+SUMMARY = "Firmware packages for the DragonBoard 820c board"
+
+inherit packagegroup
+
+RRECOMMENDS:${PN} += " \
+    firmware-qcom-dragonboard820c \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a530', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
+    linux-firmware-qcom-venus-4.2 \
+"

--- a/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard845c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard845c.bb
@@ -1,0 +1,13 @@
+SUMMARY = "Firmware packages for the DragonBoard 845c board"
+
+inherit packagegroup
+
+RRECOMMENDS:${PN} += " \
+    firmware-qcom-dragonboard845c \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k linux-firmware-qcom-sdm845-modem', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca linux-firmware-qcom-sdm845-modem', '', d)} \
+    linux-firmware-qcom-sdm845-audio \
+    linux-firmware-qcom-sdm845-compute \
+    linux-firmware-qcom-venus-5.2 \
+"

--- a/recipes-bsp/packagegroups/packagegroup-firmware-rb5.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-rb5.bb
@@ -1,0 +1,14 @@
+SUMMARY = "Firmware packages for the RB5 Robotics platform"
+
+inherit packagegroup
+
+RRECOMMENDS:${PN} += " \
+    firmware-qcom-rb5 \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a630', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath11k', '', d)} \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
+    linux-firmware-lt9611uxc \
+    linux-firmware-qcom-sm8250-audio \
+    linux-firmware-qcom-sm8250-compute \
+    linux-firmware-qcom-vpu-1.0 \
+"

--- a/recipes-test/images/initramfs-firmware-image.bb
+++ b/recipes-test/images/initramfs-firmware-image.bb
@@ -1,0 +1,21 @@
+DESCRIPTION = "Tiny ramdisk image with firmware files"
+
+PACKAGE_INSTALL = " \
+    packagegroup-firmware-dragonboard410c \
+    packagegroup-firmware-dragonboard820c \
+    packagegroup-firmware-dragonboard845c \
+    packagegroup-firmware-rb5 \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'wireless-regdb-static', '', d)} \
+"
+
+IMAGE_LINGUAS = ""
+LICENSE = "MIT"
+
+IMAGE_FSTYPES = "${INITRAMFS_FSTYPES}"
+inherit core-image
+
+IMAGE_ROOTFS_SIZE = "8192"
+IMAGE_ROOTFS_EXTRA_SPACE = "0"
+
+# Inhibit installing /init
+IMAGE_BUILDING_DEBUGFS = "true"


### PR DESCRIPTION
To remove duplication between qcom-armv8a and other board files and to ease using firmware configuration in e.g. initramfs images create per-board firmware packagegroups.