### PR TITLE
recipes-graphics: mesa_git fix installation of new all-skips.txt

### DIFF
--- a/recipes-graphics/mesa/mesa_git.bb
+++ b/recipes-graphics/mesa/mesa_git.bb
@@ -27,7 +27,7 @@ FILES:${PN}-ci = "${bindir}/deqp-runner.sh ${datadir}/mesa/deqp-*"
 do_install:append () {
     install -d ${D}/${datadir}/mesa
 
-    install -m 0644 ${S}/.gitlab-ci/deqp-all-skips.txt ${D}/${datadir}/mesa/
+    install -m 0644 ${S}/.gitlab-ci/all-skips.txt ${D}/${datadir}/mesa/
     for f in ${S}/src/freedreno/ci/deqp-freedreno-*; do
         install -m 0644 $f ${D}/${datadir}/mesa/
     done


### PR DESCRIPTION
The deqp-all-skips.txt was renamed to all-skips.txt, see:

https://gitlab.freedesktop.org/mesa/mesa/-/commit/38dff02bfb1f237ded1e2075e560ec06b52fadcf

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>