### PR TITLE
bootrr, diag: make sure branch and protocol are configured

### DIFF
--- a/recipes-test/bootrr/bootrr_git.bb
+++ b/recipes-test/bootrr/bootrr_git.bb
@@ -5,7 +5,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=987293312a134ab40eec5f3d446cfaff"
 
 SRCREV = "d2329902b701e0efa345628471d0d275d5a5835a"
 SRC_URI = "\
-	git://github.com/andersson/bootrr.git \
+	git://github.com/andersson/bootrr.git;branch=master;protocol=https \
 	file://bootrr-auto-switch-to-using-sh.patch \
 "
 

--- a/recipes-test/diag/diag_git.bb
+++ b/recipes-test/diag/diag_git.bb
@@ -3,7 +3,7 @@ HOMEPAGE = "https://github.com/andersson/diag"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=f6832ae4af693c6f31ffd931e25ef580"
 
-SRC_URI = "git://github.com/andersson/diag.git;protocol=https \
+SRC_URI = "git://github.com/andersson/diag.git;branch=master;protocol=https \
            file://0001-Disable-use-of-__NR_io_getevents-when-not-defined.patch \
            "
 


### PR DESCRIPTION
The default branch name for new repositories created on GitHub is now
main. While it does not affect existing repo, let's be more explicit
just in case, as there is uncertainty about how it will be managed in
general.

Also Github has announced that it will stop supporting git:// protocol
in Q1 2022, let's make sure we don't use it anymore, and use
https:// instead.

https://github.blog/2021-09-01-improving-git-protocol-security-github/#no-more-unauthenticated-git

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>