### PR TITLE
initramfs-test-full-image: Do not use append with += operator

### DIFF
--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -37,7 +37,7 @@ PACKAGE_INSTALL += " \
     wpa-supplicant \
 "
 
-PACKAGE_INSTALL:append:libc-glibc += " \
+PACKAGE_INSTALL:append:libc-glibc = " \
     rt-tests \
 "
 


### PR DESCRIPTION
this is undefined behaviour, mant times devs used them together to get
the missing space at the beginning of string which append/prepend needs
but thats not intended behaviour

Signed-off-by: Khem Raj <raj.khem@gmail.com>