### PR TITLE
Update firmware packages

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-dragonboard410c.inc
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard410c.inc
@@ -5,21 +5,21 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=4d087ee0965cb059f1b2f9429e166f64"
 
 DEPENDS += "mtools-native pil-squasher-native"
 
-FW_QCOM_NAME = "msm8916"
+FW_QCOM_NAME = "apq8016"
 
 require recipes-bsp/firmware/firmware-qcom.inc
 
 S = "${WORKDIR}/linux-board-support-package-r${PV}"
 
 do_install() {
-    install -d  ${D}${nonarch_base_libdir}/firmware/
-
     install -d  ${D}/boot
     cp ./efs-seed/fs_image_linux.tar.gz.mbn.img ${D}/boot/modem_fsg
 
-    cp -r ./proprietary-linux/wlan ${D}${nonarch_base_libdir}/firmware/
+    install -d ${D}${FW_QCOM_PATH}
 
-    install -d  ${D}${FW_QCOM_PATH}
+    install -m 0644 ./proprietary-linux/wlan/prima/WCNSS_qcom_wlan_nv.bin \
+                 ${D}${FW_QCOM_PATH}/WCNSS_qcom_wlan_nv_sbc.bin
+
     MTOOLS_SKIP_CHECK=1 mcopy -i ./bootloaders-linux/NON-HLOS.bin \
     ::image/modem.* ::image/mba.mbn ::image/wcnss.* ${D}${FW_QCOM_PATH}
 
@@ -31,6 +31,17 @@ do_install() {
 
     install -d ${D}${sysconfdir}/
     install -m 0644 LICENSE ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE-${PN}
+
+    # compat for Linux kernel <= 5.15
+    install -d ${D}${nonarch_base_libdir}/firmware/wlan/prima
+    install -m 0644 ./proprietary-linux/wlan/prima/WCNSS_qcom_wlan_nv.bin \
+                 ${D}${nonarch_base_libdir}/firmware/wlan/prima/
+
+    install -d ${D}${FW_QCOM_BASE_PATH}/msm8916
+    for file in ${D}${FW_QCOM_PATH}/*.mbn ${D}${FW_QCOM_PATH}/*.mdt ${D}${FW_QCOM_PATH}/*.b*
+    do
+        ln -s ../apq8016/$(basename $file) ${D}${FW_QCOM_BASE_PATH}/msm8916/
+    done
 }
 
 FILES:${PN} += "/boot/modem_fsg"

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard410c.inc
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard410c.inc
@@ -19,15 +19,15 @@ do_install() {
 
     cp -r ./proprietary-linux/wlan ${D}${nonarch_base_libdir}/firmware/
 
-    install -d  ${D}${nonarch_base_libdir}/firmware/qcom/msm8916
+    install -d  ${D}${FW_QCOM_PATH}
     MTOOLS_SKIP_CHECK=1 mcopy -i ./bootloaders-linux/NON-HLOS.bin \
-    ::image/modem.* ::image/mba.mbn ::image/wcnss.* ${D}${nonarch_base_libdir}/firmware/qcom/msm8916
+    ::image/modem.* ::image/mba.mbn ::image/wcnss.* ${D}${FW_QCOM_PATH}
 
-    pil-squasher ${D}${nonarch_base_libdir}/firmware/qcom/msm8916/modem.mbn \
-                 ${D}${nonarch_base_libdir}/firmware/qcom/msm8916/modem.mdt
+    pil-squasher ${D}${FW_QCOM_PATH}/modem.mbn \
+                 ${D}${FW_QCOM_PATH}/modem.mdt
 
-    pil-squasher ${D}${nonarch_base_libdir}/firmware/qcom/msm8916/wcnss.mbn \
-                 ${D}${nonarch_base_libdir}/firmware/qcom/msm8916/wcnss.mdt
+    pil-squasher ${D}${FW_QCOM_PATH}/wcnss.mbn \
+                 ${D}${FW_QCOM_PATH}/wcnss.mdt
 
     install -d ${D}${sysconfdir}/
     install -m 0644 LICENSE ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE-${PN}

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard820c_01700.1.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard820c_01700.1.bb
@@ -7,7 +7,7 @@ SRC_URI = "https://releases.linaro.org/96boards/dragonboard820c/qualcomm/firmwar
 SRC_URI[md5sum] = "587138c5e677342db9a88d5c8747ec6c"
 SRC_URI[sha256sum] = "6ee9c461b2b5dd2d3bd705bb5ea3f44b319ecb909b2772f305ce12439e089cd9"
 
-FW_QCOM_NAME = "msm8996"
+FW_QCOM_NAME = "apq8096"
 
 require recipes-bsp/firmware/firmware-qcom.inc
 
@@ -36,6 +36,13 @@ do_install() {
 
     install -d ${D}${sysconfdir}/
     install -m 0644 LICENSE ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE-${PN}
+
+    # compat for Linux kernel <= 5.15
+    install -d ${D}${FW_QCOM_BASE_PATH}/msm8996
+    for file in ${D}${FW_QCOM_PATH}/*.mbn ${D}${FW_QCOM_PATH}/*.mdt ${D}${FW_QCOM_PATH}/*.b*
+    do
+        ln -s ../apq8096/$(basename $file) ${D}${FW_QCOM_BASE_PATH}/msm8996/
+    done
 }
 
 inherit update-alternatives

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard820c_01700.1.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard820c_01700.1.bb
@@ -24,12 +24,12 @@ do_compile() {
 
 do_install() {
     install -d ${D}${nonarch_base_libdir}/firmware/
-    install -d ${D}${nonarch_base_libdir}/firmware/qcom/msm8996/
+    install -d ${D}${FW_QCOM_PATH}/
     
-    install -m 0444 ./proprietary-linux/adsp*.* ${D}${nonarch_base_libdir}/firmware/qcom/msm8996/
-    pil-squasher ${D}${nonarch_base_libdir}/firmware/qcom/msm8996/adsp.mbn ./proprietary-linux/adsp.mdt
+    install -m 0444 ./proprietary-linux/adsp*.* ${D}${FW_QCOM_PATH}/
+    pil-squasher ${D}${FW_QCOM_PATH}/adsp.mbn ./proprietary-linux/adsp.mdt
 
-    install -m 0444 ./bootloaders-linux/adspso.bin ${D}${nonarch_base_libdir}/firmware/qcom/msm8996/
+    install -m 0444 ./bootloaders-linux/adspso.bin ${D}${FW_QCOM_PATH}/
 
     install -d ${D}${nonarch_base_libdir}/firmware/ath10k/QCA6174/hw3.0/
     install -m 0444 ${S}/board-2.bin ${D}${nonarch_base_libdir}/firmware/ath10k/QCA6174/hw3.0/board-2.bin

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
@@ -11,7 +11,7 @@ FW_QCOM_NAME = "sdm845"
 
 require recipes-bsp/firmware/firmware-qcom.inc
 
-DEPENDS += "qca-swiss-army-knife-native"
+DEPENDS += "qca-swiss-army-knife-native pil-squasher-native"
 inherit python3native
 
 do_compile() {
@@ -31,6 +31,11 @@ do_install() {
     install -m 0444 ./20-adsp_split/firmware/adsp*.* ${D}${FW_QCOM_PATH}
     install -m 0444 ./21-cdsp_split/firmware/cdsp*.* ${D}${FW_QCOM_PATH}
 
+    install -m 0444 ./39-jsn/slpi*.jsn  ${D}${FW_QCOM_PATH}
+
+    pil-squasher ${D}${FW_QCOM_PATH}/slpi.mbn \
+                 ./30-slpi_split/slpi.mdt
+
     install -d ${D}${nonarch_base_libdir}/firmware/ath10k/WCN3990/hw1.0/
     install -m 0444 ./board-2.bin ${D}${nonarch_base_libdir}/firmware/ath10k/WCN3990/hw1.0/
 
@@ -44,6 +49,7 @@ SPLIT_FIRMWARE_PACKAGES = " \
     linux-firmware-qcom-${FW_QCOM_NAME}-audio-split \
     linux-firmware-qcom-${FW_QCOM_NAME}-compute-split \
     linux-firmware-qcom-${FW_QCOM_NAME}-modem-split \
+    linux-firmware-qcom-${FW_QCOM_NAME}-sensors \
 "
 
 FILES:linux-firmware-qcom-adreno-a630-split = "${FW_QCOM_BASE_PATH}/a630_zap.*"

--- a/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
@@ -22,14 +22,14 @@ do_compile() {
 
 do_install() {
     install -d ${D}${nonarch_base_libdir}/firmware/
-    install -d ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
+    install -d ${D}${FW_QCOM_PATH}
 
-    install -m 0444 ./08-dspso/dspso.bin ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
+    install -m 0444 ./08-dspso/dspso.bin ${D}${FW_QCOM_PATH}
 
     install -m 0444 ./17-USB3-201-202-FW/K2026090.mem ${D}${nonarch_base_libdir}/firmware/renesas_usb_fw.mem
     install -m 0444 ./18-adreno-fw/a630_zap*.* ${D}${nonarch_base_libdir}/firmware/qcom/
-    install -m 0444 ./20-adsp_split/firmware/adsp*.* ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
-    install -m 0444 ./21-cdsp_split/firmware/cdsp*.* ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
+    install -m 0444 ./20-adsp_split/firmware/adsp*.* ${D}${FW_QCOM_PATH}
+    install -m 0444 ./21-cdsp_split/firmware/cdsp*.* ${D}${FW_QCOM_PATH}
 
     install -d ${D}${nonarch_base_libdir}/firmware/ath10k/WCN3990/hw1.0/
     install -m 0444 ./board-2.bin ${D}${nonarch_base_libdir}/firmware/ath10k/WCN3990/hw1.0/

--- a/recipes-bsp/firmware/firmware-qcom-nexus7-2013.bb
+++ b/recipes-bsp/firmware/firmware-qcom-nexus7-2013.bb
@@ -9,6 +9,8 @@ SRC_URI[google.md5sum] = "5c21950c751544cc92b5fe95c6f3be37"
 SRC_URI[google.sha256sum] = "1ccc740a461be8ea84369b1c13fc89cb3f26f8bc1400fedec8b3dd1f630a7994"
 SRCREV_aosp = "9d9fee956a9c4c7be4f69f7a472d3fc0e759c2dd"
 
+FW_QCOM_NAME = "flo"
+
 require recipes-bsp/firmware/firmware-qcom.inc
 
 DEPENDS += "pil-squasher-native"
@@ -27,14 +29,14 @@ do_compile() {
 }
 
 do_install() {
-    install -d  ${D}${nonarch_base_libdir}/firmware/qcom/flo
-    install -m 0644 ${B}/*.mbn ${D}${nonarch_base_libdir}/firmware/qcom/flo
-    install -m 0644 vendor/qcom/flo/proprietary/vidcfw.elf ${D}${nonarch_base_libdir}/firmware/qcom/flo
-    install -m 0644 vendor/qcom/flo/proprietary/vidc_1080p.fw ${D}${nonarch_base_libdir}/firmware/qcom/flo
+    install -d  ${D}${FW_QCOM_PATH}
+    install -m 0644 ${B}/*.mbn ${D}${FW_QCOM_PATH}
+    install -m 0644 vendor/qcom/flo/proprietary/vidcfw.elf ${D}${FW_QCOM_PATH}
+    install -m 0644 vendor/qcom/flo/proprietary/vidc_1080p.fw ${D}${FW_QCOM_PATH}
 
-    install -m 0644 license.txt ${D}${nonarch_base_libdir}/firmware/qcom/flo
+    install -m 0644 license.txt ${D}${FW_QCOM_PATH}
 
-    install -m 0644 ${WORKDIR}/git/WCNSS_cfg.dat ${D}${nonarch_base_libdir}/firmware/qcom/flo
-    install -m 0644 ${WORKDIR}/git/WCNSS_qcom_wlan_nv_deb.bin ${D}${nonarch_base_libdir}/firmware/qcom/flo
-    install -m 0644 ${WORKDIR}/git/WCNSS_qcom_wlan_nv_flo.bin ${D}${nonarch_base_libdir}/firmware/qcom/flo/WCNSS_qcom_wlan_nv.bin
+    install -m 0644 ${WORKDIR}/git/WCNSS_cfg.dat ${D}${FW_QCOM_PATH}
+    install -m 0644 ${WORKDIR}/git/WCNSS_qcom_wlan_nv_deb.bin ${D}${FW_QCOM_PATH}
+    install -m 0644 ${WORKDIR}/git/WCNSS_qcom_wlan_nv_flo.bin ${D}${FW_QCOM_PATH}/WCNSS_qcom_wlan_nv.bin
 }

--- a/recipes-bsp/firmware/firmware-qcom-rb5_20210331-v4.bb
+++ b/recipes-bsp/firmware/firmware-qcom-rb5_20210331-v4.bb
@@ -27,12 +27,12 @@ do_compile() {
 }
 
 do_install() {
-    install -d ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
+    install -d ${D}${FW_QCOM_PATH}
 
-    install -m 0444 ./08-dspso/dspso.bin ${D}${nonarch_base_libdir}/firmware/qcom/sm8250
+    install -m 0444 ./08-dspso/dspso.bin ${D}${FW_QCOM_PATH}
 
-    install -m 0444 ./30-slpi_split/slpi.mbn  ${D}${nonarch_base_libdir}/firmware/qcom/sm8250/
-    install -m 0444 ./39-jsn/slpi*.jsn  ${D}${nonarch_base_libdir}/firmware/qcom/sm8250/
+    install -m 0444 ./30-slpi_split/slpi.mbn  ${D}${FW_QCOM_PATH}/
+    install -m 0444 ./39-jsn/slpi*.jsn  ${D}${FW_QCOM_PATH}/
 
     install -d ${D}${nonarch_base_libdir}/firmware/ath11k/QCA6390/hw2.0/
     install -m 0444 ${S}/board-2.bin ${D}${nonarch_base_libdir}/firmware/ath11k/QCA6390/hw2.0/board-2.bin


### PR DESCRIPTION
- Simplify scripts by using FW_QCOM_PATH
- Follow upstream changes to use apq8016/apq8096 instead of msm8916/msm8996
- Package slpi firmware for the db845c.