### PR TITLE
initramfs-rootfs-image: add initramfs that pivots into rootfs

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,4 +17,6 @@ BBFILES_DYNAMIC += " \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bbappend \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bb \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bbappend \
+    meta-linux-mainline:${LAYERDIR}/dynamic-layers/meta-linux-mainline/*/*/*.bb \
+    meta-linux-mainline:${LAYERDIR}/dynamic-layers/meta-linux-mainline/*/*/*.bbappend \
 "

--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -9,7 +9,7 @@ EXTRA_IMAGECMD:ext4 += " -b 4096 "
 # Support for dragonboard{410, 820, 845}c, rb5
 KERNEL_IMAGETYPE ?= "Image.gz"
 SERIAL_CONSOLE ?= "115200 ttyMSM0"
-KERNEL_DEVICETREE ?= "qcom/apq8016-sbc.dtb qcom/apq8096-db820c.dtb qcom/sdm845-db845c.dtb qcom/qrb5165-rb5.dtb qcom/sm8250-rb5-dvt.dtb"
+KERNEL_DEVICETREE ?= "qcom/apq8016-sbc.dtb qcom/apq8096-db820c.dtb qcom/sdm845-db845c.dtb qcom/qrb5165-rb5.dtb"
 
 QCOM_BOOTIMG_PAGE_SIZE[apq8016-sbc] = "2048"
 QCOM_BOOTIMG_ROOTFS = "/dev/sda1"

--- a/conf/machine/qrb5165-rb5.conf
+++ b/conf/machine/qrb5165-rb5.conf
@@ -7,7 +7,7 @@ require conf/machine/include/qcom-sm8250.inc
 MACHINE_FEATURES = "usbhost usbgadget alsa screen wifi bluetooth ext2"
 
 KERNEL_IMAGETYPE ?= "Image.gz"
-KERNEL_DEVICETREE ?= "qcom/qrb5165-rb5.dtb qcom/sm8250-rb5-dvt.dtb"
+KERNEL_DEVICETREE ?= "qcom/qrb5165-rb5.dtb"
 KERNEL_CMDLINE_EXTRA ?= "pcie_pme=nomsi"
 
 SERIAL_CONSOLE ?= "115200 ttyMSM0"

--- a/dynamic-layers/meta-linux-mainline/recipes-kernel/linux/linux-mainline.bbappend
+++ b/dynamic-layers/meta-linux-mainline/recipes-kernel/linux/linux-mainline.bbappend
@@ -1,0 +1,1 @@
+include linux-mainline.inc

--- a/dynamic-layers/meta-linux-mainline/recipes-kernel/linux/linux-mainline.inc
+++ b/dynamic-layers/meta-linux-mainline/recipes-kernel/linux/linux-mainline.inc
@@ -1,0 +1,4 @@
+require recipes-kernel/linux/linux-qcom-bootimg.inc
+
+KBUILD_DEFCONFIG:qcom = "defconfig"
+KBUILD_DEFCONFIG:qcom:arm = "qcom_defconfig"

--- a/dynamic-layers/meta-linux-mainline/recipes-kernel/linux/linux-stable_%.bbappend
+++ b/dynamic-layers/meta-linux-mainline/recipes-kernel/linux/linux-stable_%.bbappend
@@ -1,0 +1,1 @@
+include linux-mainline.inc

--- a/recipes-kernel/images/initramfs-qcom-image.bb
+++ b/recipes-kernel/images/initramfs-qcom-image.bb
@@ -1,0 +1,5 @@
+require initramfs-rootfs-image.bb
+
+DESCRIPTION = "Ramdisk image for pivoting into rootfs extended to boot Qualcomm boards"
+
+PACKAGE_INSTALL += "packagegroup-qcom-boot"

--- a/recipes-kernel/images/initramfs-rootfs-image.bb
+++ b/recipes-kernel/images/initramfs-rootfs-image.bb
@@ -1,0 +1,22 @@
+DESCRIPTION = "Ramdisk image for pivoting into rootfs"
+
+PACKAGE_INSTALL = " \
+    base-passwd \
+    initramfs-module-rootfs \
+    initramfs-module-udev \
+    ${VIRTUAL-RUNTIME_base-utils} \
+    ${MACHINE_ESSENTIAL_EXTRA_RDEPENDS} \
+    ${ROOTFS_BOOTSTRAP_INSTALL} \
+"
+
+# Do not pollute the initrd image with rootfs features
+IMAGE_FEATURES = "debug-tweaks"
+IMAGE_LINGUAS = ""
+
+LICENSE = "MIT"
+
+IMAGE_FSTYPES = "${INITRAMFS_FSTYPES}"
+inherit core-image
+
+IMAGE_ROOTFS_SIZE = "8192"
+IMAGE_ROOTFS_EXTRA_SPACE = "0"

--- a/recipes-kernel/images/initramfs-rootfs-image.bb
+++ b/recipes-kernel/images/initramfs-rootfs-image.bb
@@ -2,6 +2,7 @@ DESCRIPTION = "Ramdisk image for pivoting into rootfs"
 
 PACKAGE_INSTALL = " \
     base-passwd \
+    initramfs-module-copy-modules \
     initramfs-module-rootfs \
     initramfs-module-udev \
     ${VIRTUAL-RUNTIME_base-utils} \

--- a/recipes-kernel/linux/linux-qcom-bootimg.inc
+++ b/recipes-kernel/linux/linux-qcom-bootimg.inc
@@ -144,3 +144,6 @@ addtask do_qcom_img_deploy_setscene
 do_qcom_img_deploy[dirs] = "${QIMG_DEPLOYDIR} ${B}"
 do_qcom_img_deploy[cleandirs] = "${QIMG_DEPLOYDIR}"
 do_qcom_img_deploy[stamp-extra-info] = "${MACHINE_ARCH}"
+
+# We do not need kernel image in /boot, these images are flashed into separate partition.
+RDEPENDS:${KERNEL_PACKAGE_NAME}-base = ""

--- a/recipes-kernel/packagegroups/packagegroup-qcom-boot.bb
+++ b/recipes-kernel/packagegroups/packagegroup-qcom-boot.bb
@@ -1,0 +1,13 @@
+SUMMARY = "Qualcomm boot requirements"
+DESCRIPTION = "A set of packages required to find the rootfs on the generic Qualcomm board"
+
+inherit packagegroup
+
+# Recommend the packages as some of them might end up being built-in
+# qcom-pon is not strictly required, but it would be good to handle events if something goes wrong
+RRECOMMENDS:${PN} = " \
+    kernel-module-phy-qcom-qmp \
+    kernel-module-qcom-pon \
+    kernel-module-qnoc-sm8250 \
+    kernel-module-ufs-qcom \
+"

--- a/recipes-support/initrdscripts/files/copy-modules.sh
+++ b/recipes-support/initrdscripts/files/copy-modules.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Copyright (C) 2022 Linaro Ltd.
+# Licensed on MIT
+
+copy_modules_enabled() {
+	[ -n "${bootparam_copy_modules}" -a -d /lib/modules/`uname -r` ]
+}
+
+copy_modules_run() {
+	if [ -n "$ROOTFS_DIR" ]; then
+		rm -rf $ROOTFS_DIR/lib/modules/`uname -r`
+		mkdir -p $ROOTFS_DIR/lib/modules
+		cp -a /lib/modules/`uname -r` $ROOTFS_DIR/lib/modules
+	else
+		debug "No rootfs has been set"
+	fi
+}

--- a/recipes-support/initrdscripts/initramfs-module-copy-modules_1.0.bb
+++ b/recipes-support/initrdscripts/initramfs-module-copy-modules_1.0.bb
@@ -1,0 +1,15 @@
+SUMMARY = "initramfs-framework module for copying kernel modules from initramfs to rootfs"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+RDEPENDS:${PN} = "initramfs-framework-base ${VIRTUAL-RUNTIME_base-utils}"
+
+SRC_URI = "file://copy-modules.sh"
+
+S = "${WORKDIR}"
+
+do_install() {
+    install -d ${D}/init.d
+    install -m 0755 ${WORKDIR}/copy-modules.sh ${D}/init.d/95-copy_modules
+}
+
+FILES:${PN} = "/init.d/"


### PR DESCRIPTION
Add small initramfs image that will detect, mount and switch into
specified rootfs. At this moment this recipe does not pull any kernel
modules on its own, users of the initramfs have to do that on their own.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>