### PR TITLE
Rework initramfs-test-image family of images

### DIFF
--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -1,40 +1,20 @@
-require recipes-test/images/initramfs-tiny-image.bb
+require recipes-test/images/initramfs-test-image.bb
 
 DESCRIPTION = "Relatively larger ramdisk image for running tests (bootrr, etc)"
 
 PACKAGE_INSTALL += " \
-    bluez5 \
     bootrr \
     coreutils \
-    dhcpcd \
-    diag \
-    e2fsprogs \
-    e2fsprogs-e2fsck \
-    e2fsprogs-mke2fs \
-    e2fsprogs-resize2fs \
-    e2fsprogs-tune2fs \
-    ethtool \
-    gptfdisk \
-    iw \
     hdparm \
     kexec \
-    lava-test-shell \
-    libdrm-tests \
     lsof \
     ncurses \
     ncurses-terminfo \
     ncurses-terminfo-base \
-    pciutils \
-    pd-mapper \
-    qrtr \
-    rmtfs \
     stress-ng \
-    tqftpserv \
-    usbutils \
     util-linux \
     util-linux-chrt \
     util-linux-lsblk \
-    wpa-supplicant \
 "
 
 PACKAGE_INSTALL:append:libc-glibc = " \
@@ -46,8 +26,6 @@ PACKAGE_INSTALL:append:libc-glibc = " \
 # one would not get all these tools. So simulate dynamic bbappend here.
 PACKAGE_INSTALL_openembedded_layer += " \
     crash \
-    cryptsetup \
-    devmem2 \
     dhrystone \
     iozone3 \
     libgpiod \
@@ -60,12 +38,3 @@ PACKAGE_INSTALL_openembedded_layer += " \
     tiobench \
     whetstone \
 "
-
-PACKAGE_INSTALL_networking_layer += " \
-    iperf2 \
-    iperf3 \
-    tcpdump \
-"
-
-PACKAGE_INSTALL += "${@bb.utils.contains("BBFILE_COLLECTIONS", "openembedded-layer", "${PACKAGE_INSTALL_openembedded_layer}", "", d)}"
-PACKAGE_INSTALL += "${@bb.utils.contains("BBFILE_COLLECTIONS", "networking-layer", "${PACKAGE_INSTALL_networking_layer}", "", d)}"

--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -24,7 +24,7 @@ PACKAGE_INSTALL:append:libc-glibc = " \
 # We'd like to include extra packages provided by layers which we do not depend
 # on. This can be handled by .bbappends, but then image recipes including this
 # one would not get all these tools. So simulate dynamic bbappend here.
-PACKAGE_INSTALL_openembedded_layer += " \
+PACKAGE_INSTALL_openembedded-layer += " \
     crash \
     dhrystone \
     iozone3 \

--- a/recipes-test/images/initramfs-test-image.bb
+++ b/recipes-test/images/initramfs-test-image.bb
@@ -28,16 +28,13 @@ PACKAGE_INSTALL += " \
 # We'd like to include extra packages provided by layers which we do not depend
 # on. This can be handled by .bbappends, but then image recipes including this
 # one would not get all these tools. So simulate dynamic bbappend here.
-PACKAGE_INSTALL_openembedded_layer += " \
+PACKAGE_INSTALL_openembedded-layer += " \
     cryptsetup \
     devmem2 \
 "
 
-PACKAGE_INSTALL_networking_layer += " \
+PACKAGE_INSTALL_networking-layer += " \
     iperf2 \
     iperf3 \
     tcpdump \
 "
-
-PACKAGE_INSTALL += "${@bb.utils.contains("BBFILE_COLLECTIONS", "openembedded-layer", "${PACKAGE_INSTALL_openembedded_layer}", "", d)}"
-PACKAGE_INSTALL += "${@bb.utils.contains("BBFILE_COLLECTIONS", "networking-layer", "${PACKAGE_INSTALL_networking_layer}", "", d)}"

--- a/recipes-test/images/initramfs-tiny-image.bb
+++ b/recipes-test/images/initramfs-tiny-image.bb
@@ -33,3 +33,16 @@ local_autologin () {
     sed -i -e 's/^\(ExecStart *=.*getty \)/\1--autologin root /' ${LOCAL_GETTY}
 }
 ROOTFS_POSTPROCESS_COMMAND += "${@oe.utils.conditional('VIRTUAL-RUNTIME_init_manager', 'systemd', 'local_autologin;', '', d)}"
+
+# We'd like to include extra packages provided by layers which we do not depend
+# on. This can be handled by .bbappends, but then image recipes including this
+# one would not get all these tools. So simulate dynamic bbappend here.
+#
+# To use it define PACKAGE_INSTALL_foo-layer variable containing the list of
+# packages to be installed if (and only if) layer foo-layer is enabled.
+python() {
+    for layer in d.getVar("BBFILE_COLLECTIONS", True).split():
+        extra = d.getVar("PACKAGE_INSTALL_%s" % layer)
+        if extra:
+            d.appendVar("PACKAGE_INSTALL", " " + extra)
+}


### PR DESCRIPTION
- remove duplication between `test` and `test-full` images
- handle `PACKAGE_INSTAL_foo-layer` automatically rather than listing them manually.