### PR TITLE
linux-linaro-qcomlt-dev: revert dtschema enforced enabling

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt-dev.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-dev.bb
@@ -16,5 +16,7 @@ SRCBRANCH = "integration-linux-qcomlt"
 # anonymous python routine and resolved when the variables are finalized.
 SRCREV ?= '${@oe.utils.conditional("PREFERRED_PROVIDER_virtual/kernel", "linux-linaro-qcomlt-dev", "${AUTOREV}", "29594404d7fe73cd80eaa4ee8c43dcc53970c60e", d)}'
 
+SRC_URI += "file://0001-Revert-kbuild-Enable-DT-schema-checks-for-.dtb-targe.patch"
+
 LINUX_VERSION = "5.11+"
 PV = "${LINUX_VERSION}+git${SRCPV}"

--- a/recipes-kernel/linux/linux-linaro-qcomlt-dev/0001-Revert-kbuild-Enable-DT-schema-checks-for-.dtb-targe.patch
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-dev/0001-Revert-kbuild-Enable-DT-schema-checks-for-.dtb-targe.patch
@@ -1,0 +1,48 @@
+From 8f391e49c75b8328f2562b3f5323530e0707b46b Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Wed, 24 Nov 2021 11:15:55 +0300
+Subject: [PATCH] Revert "kbuild: Enable DT schema checks for %.dtb targets"
+
+This reverts commit 53182e81f47d4ea0c727c49ad23cb782173ab849.
+
+There is no need to check dtb schema while building OE kernel images.
+Not to mention that supporting dtschema properly requires significant
+changes to the OE-core layer (which are still pending). With all that in
+mind revert the commit making dtschema validation mandatory when
+building individual dtb files.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+---
+ Makefile | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index daf95a574b08..fdd75ef39d88 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1374,17 +1374,17 @@ endif
+ 
+ ifneq ($(dtstree),)
+ 
+-%.dtb: dt_binding_check include/config/kernel.release scripts_dtc
+-	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@ $(dtstree)/$*.dt.yaml
++%.dtb: include/config/kernel.release scripts_dtc
++	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
+ 
+-%.dtbo: dt_binding_check include/config/kernel.release scripts_dtc
+-	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@ $(dtstree)/$*.dt.yaml
++%.dtbo: include/config/kernel.release scripts_dtc
++	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
+ 
+ PHONY += dtbs dtbs_install dtbs_check
+ dtbs: include/config/kernel.release scripts_dtc
+ 	$(Q)$(MAKE) $(build)=$(dtstree)
+ 
+-ifneq ($(filter dtbs_check %.dtb %.dtbo, $(MAKECMDGOALS)),)
++ifneq ($(filter dtbs_check, $(MAKECMDGOALS)),)
+ export CHECK_DTBS=y
+ dtbs: dt_binding_check
+ endif
+-- 
+2.30.2
+


### PR DESCRIPTION
There is no need to check dtb schema while building OE kernel images.
Not to mention that supporting dtschema properly requires significant
changes to the OE-core layer (which are still pending). With all that in
mind revert the commit making dtschema validation mandatory when
building individual dtb files.

Revert the patch here rather than in the integration tree itself, so
that users of the integration tree still can benefit from enforced dt
schema validation.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>