### PR TITLE
initramfs-test-image: add adbd support

### DIFF
--- a/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-adbd-cmdline.bb
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-adbd-cmdline.bb
@@ -1,0 +1,17 @@
+DESCRIPTION = "An override for adbd unit - start adbd depending on the kernel command line"
+SECTION = "console/utils"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://50-adbd-cmdline.conf \
+"
+
+do_install() {
+    install -d ${D}${systemd_unitdir}/system/android-tools-adbd.service.d
+    install -m 0644 ${WORKDIR}/50-adbd-cmdline.conf ${D}${systemd_unitdir}/system/android-tools-adbd.service.d
+}
+
+FILES:${PN} += " \
+    ${systemd_unitdir}/system/ \
+"

--- a/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-adbd-cmdline/50-adbd-cmdline.conf
+++ b/dynamic-layers/openembedded-layer/recipes-devtools/android-tools/android-tools-adbd-cmdline/50-adbd-cmdline.conf
@@ -1,0 +1,6 @@
+[Unit]
+# Clear all conditions
+ConditionPathExists=
+# And start if kernel adbd argument is provided or if the file exists
+ConditionPathExists=|/var/usb-debugging-enabled
+ConditionKernelCommandLine=|adbd

--- a/recipes-test/images/initramfs-test-image.bb
+++ b/recipes-test/images/initramfs-test-image.bb
@@ -41,6 +41,8 @@ PACKAGE_INSTALL += " \
 # on. This can be handled by .bbappends, but then image recipes including this
 # one would not get all these tools. So simulate dynamic bbappend here.
 PACKAGE_INSTALL_openembedded-layer += " \
+    android-tools-adbd \
+    android-tools-adbd-cmdline \
     cpufrequtils \
     cryptsetup \
     devmem2 \


### PR DESCRIPTION
Install and enable adbd if meta-openmebedded is enabled.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>