### PR TITLE
recipes-kernel: Linux 5.15 bump to rev 43aa1d1f5fcf (v5.15.6)

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
@@ -4,7 +4,7 @@
 require recipes-kernel/linux/linux-linaro-qcom.inc
 
 # SRCBRANCH set to "release/qcomlt-5.15" in linux-linaro-qcom.inc
-SRCREV = "485c2c5a3ccea0a1026a87869c2268e538a0b848"
+SRCREV = "43aa1d1f5fcf5d68f07821b0b3a9314f7c7af649"
 
 SRCBRANCH:sa8155p = "release/sa8155p-adp/qcomlt-5.15"
 SRCREV:sa8155p = "3290018e72cdf6a1b90e672710ad2a6dda9fffd6"


### PR DESCRIPTION
Changes,

43aa1d1f5fcf Merge tag 'v5.15.6' into HEAD
...
485c2c5a3cce drivers/net/wireless/ath: ath11k wmi restore mgmt_rx_event_params.chan_freq

Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>
(cherry picked from commit 6743d359e162358c74996220b23f0f572ff308a3)
Signed-off-by: Aníbal Limón <anibal.limon@linaro.org>