### PR TITLE
initramfs-test-image: Add a couple of networking related utils - conn…

### DIFF
--- a/recipes-test/images/initramfs-test-image.bb
+++ b/recipes-test/images/initramfs-test-image.bb
@@ -34,7 +34,9 @@ PACKAGE_INSTALL_openembedded-layer += " \
 "
 
 PACKAGE_INSTALL_networking-layer += " \
+    connman \
     iperf2 \
     iperf3 \
+    phytool \
     tcpdump \
 "


### PR DESCRIPTION
…man & phytool

Add a couple of networking related utils - connman & phytool
to 'initramfs-test-image' to allow easier network configuration
(auto eth address assignment) and quering / setting phy registers
(via phytool).

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>