### PR TITLE
initramfs-test-image: Add a couple of networking related utils - conn…

### DIFF
--- a/recipes-test/images/initramfs-test-image.bb
+++ b/recipes-test/images/initramfs-test-image.bb
@@ -34,8 +34,10 @@ PACKAGE_INSTALL_openembedded_layer += " \
 "
 
 PACKAGE_INSTALL_networking_layer += " \
+    connman \
     iperf2 \
     iperf3 \
+    phytool \
     tcpdump \
 "
 


### PR DESCRIPTION
…man & phytool

Add a couple of networking related utils - connman & phytool
to 'initramfs-test-image' to allow easier network configuration
(auto eth address assignment) and quering / setting phy registers
(via phytool).

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>
(cherry picked from commit 207c865217ec15fabde446d2a3099bfb4fbf61ea)