### PR TITLE
initramfs-test-image: Add a few utils

### DIFF
--- a/recipes-test/images/initramfs-test-image.bb
+++ b/recipes-test/images/initramfs-test-image.bb
@@ -6,6 +6,7 @@ PACKAGE_INSTALL += " \
     bluez5 \
     dhcp-client \
     diag \
+    dropbear \
     e2fsprogs \
     e2fsprogs-e2fsck \
     e2fsprogs-mke2fs \
@@ -20,6 +21,7 @@ PACKAGE_INSTALL += " \
     pd-mapper \
     qrtr \
     rmtfs \
+    strace \
     tqftpserv \
     usbutils \
     wpa-supplicant \
@@ -36,6 +38,7 @@ PACKAGE_INSTALL_openembedded_layer += " \
 PACKAGE_INSTALL_networking_layer += " \
     iperf2 \
     iperf3 \
+    phytool \
     tcpdump \
 "
 


### PR DESCRIPTION
Add the following utilities to 'initramfs-test-image'
to allow easier board development:

- dropbear (for ssh and scp services),
- strace (qcom requested this to be added to allow tracing kernel func
  calls),
- phytool (allows ethernet phy registers to be read / write).

This causes the initramfs-test-image.rootfs.cpio.gz size to be increased
by 0.5M.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>
(cherry picked from commit 9724a4e9acad343781b1e1997d43b37d1c06bc19)