### PR TITLE
sdx55: switch to main linux-linaro-qcoml kernel recipe

### DIFF
--- a/conf/machine/sdx55-mtp.conf
+++ b/conf/machine/sdx55-mtp.conf
@@ -16,5 +16,3 @@ UBINIZE_ARGS ?= "-m 4096 -p 256KiB -s 4096"
 # Use system partition for rootfs
 UBI_VOLNAME ?= "system"
 QCOM_BOOTIMG_ROOTFS ?= "ubi0:system"
-
-PREFERRED_PROVIDER_virtual/kernel = "linux-linaro-qcomlt-dev"

--- a/conf/machine/sdx55-telit-fn980.conf
+++ b/conf/machine/sdx55-telit-fn980.conf
@@ -18,5 +18,3 @@ UBI_VOLNAME ?= "system"
 QCOM_BOOTIMG_ROOTFS ?= "ubi0:system"
 
 SERIAL_CONSOLES = "921600;ttyMSM0"
-
-PREFERRED_PROVIDER_virtual/kernel = "linux-linaro-qcomlt-dev"


### PR DESCRIPTION
There is enough upstream support for sdx55, we no longer need to use a
custom kernel recipe.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>