### PR TITLE
conf/sa8155p-adp.conf: Don't set INITRAMFS_IMAGE for sa8155p machine

### DIFF
--- a/conf/machine/sa8155p-adp.conf
+++ b/conf/machine/sa8155p-adp.conf
@@ -4,9 +4,6 @@
 
 require conf/machine/include/qcom-sa8155p.inc
 
-# Set INITRAMFS_IMAGE for sa8155p machine
-INITRAMFS_IMAGE = "initramfs-kerneltest-full-image"
-
 MACHINE_FEATURES = "usbhost usbgadget ext2"
 
 KERNEL_IMAGETYPE ?= "Image.gz"


### PR DESCRIPTION
Since we use the rpb-console* images for sa8155p machine now,
let's not set the INITRAMFS_IMAGE as "initramfs-kerneltest-full-image"
for sa8155p machine now.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>
(cherry picked from commit 55e50888f2a8e75fecad1b74626313a516f5bad5)