### PR TITLE
cryptodev-module: Backport a patch to fix build failure with kernel v…

### DIFF
--- a/recipes-kernel/cryptodev/cryptodev-module_%.bbappend
+++ b/recipes-kernel/cryptodev/cryptodev-module_%.bbappend
@@ -1,0 +1,2 @@
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+SRC_URI:append:qcom = " file://0001-Fix-build-for-Linux-5.11-rc1.patch"

--- a/recipes-kernel/cryptodev/files/0001-Fix-build-for-Linux-5.11-rc1.patch
+++ b/recipes-kernel/cryptodev/files/0001-Fix-build-for-Linux-5.11-rc1.patch
@@ -1,0 +1,37 @@
+From 55c6315058fc0dd189ffd116f2cc27ba4fa84cb6 Mon Sep 17 00:00:00 2001
+From: Joan Bruguera <joanbrugueram@gmail.com>
+Date: Mon, 28 Dec 2020 01:41:31 +0100
+Subject: [PATCH] Fix build for Linux 5.11-rc1
+
+ksys_close was removed, as far as I can tell, close_fd replaces it.
+
+See also: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=8760c909f54a82aaa6e76da19afe798a0c77c3c3
+          https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=1572bfdf21d4d50e51941498ffe0b56c2289f783
+
+Upstream-status: Backport [55c6315058fc0dd189ffd116f2cc27ba4fa84cb6]
+
+Signed-off-by: Nishanth Menon <nm@ti.com>
+---
+ ioctl.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/ioctl.c b/ioctl.c
+index 3d33238021dc..95481d4ff8e2 100644
+--- a/ioctl.c
++++ b/ioctl.c
+@@ -871,8 +871,10 @@ cryptodev_ioctl(struct file *filp, unsigned int cmd, unsigned long arg_)
+ 		if (unlikely(ret)) {
+ #if (LINUX_VERSION_CODE < KERNEL_VERSION(4, 17, 0))
+ 			sys_close(fd);
+-#else
++#elif (LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0))
+ 			ksys_close(fd);
++#else
++			close_fd(fd);
+ #endif
+ 			return ret;
+ 		}
+-- 
+2.31.0
+
+


### PR DESCRIPTION
…5.11

Fix the following build failure with v5.11+ kernel
cryptodev-module/1.10-r0.arago0/git/authenc.c: In function 'pad_record':
cryptodev-module/1.10-r0.arago0/git/authenc.c:317:2: warning: ISO C90 forbids variable length array 'pad' [-Wvla]
 317 |  uint8_t pad[block_size];
     |  ^~~~~~~
cryptodev-module/1.10-r0.arago0/git/ioctl.c: In function 'cryptodev_ioctl':
cryptodev-module/1.10-r0.arago0/git/ioctl.c:875:4: error: implicit declaration of function 'ksys_close'; did you mean 'ksys_chown'? [-Werror=implicit-function-declaration]
 875 |    ksys_close(fd);
     |    ^~~~~~~~~~
     |    ksys_chown

OE Core does'nt plan on fixing dunfell branch up for newer kernel, and
oe master already is on 1.12 cryptodev with the fixes already in place.

Signed-off-by: Nishanth Menon <nm@ti.com>
[cherry-picked from meta-arago, included override for qcom]
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>