### PR TITLE
linux: Update SRCREV for release/sa8155p-adp/qcomlt-5.16

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.16.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.16.bb
@@ -6,4 +6,4 @@ require recipes-kernel/linux/linux-linaro-qcom.inc
 COMPATIBLE_MACHINE = "(sa8155p)"
 SRC_URI:append = " file://0001-Revert-kbuild-Enable-DT-schema-checks-for-.dtb-targe.patch"
 SRCBRANCH = "release/sa8155p-adp/qcomlt-5.16"
-SRCREV = "78b7b519e9ae3afeb32b134956b397b2f246e0b0"
+SRCREV = "8ea62eb83b9da1402d505146c529bcca87b7ba80"


### PR DESCRIPTION
Update the SRCREV in linux-linaro-qcomlt_5.16.bb file
for sa8155p adp board, which now supports
additional ethernet fixes for kernel version 5.16.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>