### PR TITLE
initramfs-test-image: enable lrzsz

### DIFF
--- a/recipes-test/images/initramfs-test-image.bb
+++ b/recipes-test/images/initramfs-test-image.bb
@@ -17,6 +17,7 @@ PACKAGE_INSTALL += " \
     iw \
     lava-test-shell \
     libdrm-tests \
+    lrzsz \
     pciutils \
     pd-mapper \
     qrtr \


### PR DESCRIPTION
Add lrzsz tool to be able to transfer files through the serial line.
The package uses 138 kiB of space.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
(cherry picked from commit 0746a3b21f63198e6c5184bc7c847f67c71e22cd)