### PR TITLE
linux: Add new .bb file for release/sa8155p-adp/qcomlt-5.16

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt/0001-Revert-kbuild-Enable-DT-schema-checks-for-.dtb-targe.patch
+++ b/recipes-kernel/linux/linux-linaro-qcomlt/0001-Revert-kbuild-Enable-DT-schema-checks-for-.dtb-targe.patch
@@ -1,0 +1,46 @@
+From 75e895343d5a2fcbdf4cb3d31ab7492bd65925f0 Mon Sep 17 00:00:00 2001
+From: Rob Herring <robh@kernel.org>
+Date: Wed, 8 Dec 2021 15:39:16 -0600
+Subject: [PATCH] Revert "kbuild: Enable DT schema checks for %.dtb targets"
+
+This reverts commit 53182e81f47d4ea0c727c49ad23cb782173ab849.
+
+This added tool dependencies on various build systems using %.dtb
+targets. Validation will need to be controlled by a kconfig or make
+variable instead, but for now let's just revert it.
+
+Signed-off-by: Rob Herring <robh@kernel.org>
+---
+ Makefile | 10 +++++-----
+ 1 file changed, 5 insertions(+), 5 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 9e12c14ea0fb..fa5070e53979 100644
+--- a/Makefile
++++ b/Makefile
+@@ -1374,17 +1374,17 @@ endif
+ 
+ ifneq ($(dtstree),)
+ 
+-%.dtb: dt_binding_check include/config/kernel.release scripts_dtc
+-	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@ $(dtstree)/$*.dt.yaml
++%.dtb: include/config/kernel.release scripts_dtc
++	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
+ 
+-%.dtbo: dt_binding_check include/config/kernel.release scripts_dtc
+-	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@ $(dtstree)/$*.dt.yaml
++%.dtbo: include/config/kernel.release scripts_dtc
++	$(Q)$(MAKE) $(build)=$(dtstree) $(dtstree)/$@
+ 
+ PHONY += dtbs dtbs_install dtbs_check
+ dtbs: include/config/kernel.release scripts_dtc
+ 	$(Q)$(MAKE) $(build)=$(dtstree)
+ 
+-ifneq ($(filter dtbs_check %.dtb %.dtbo, $(MAKECMDGOALS)),)
++ifneq ($(filter dtbs_check, $(MAKECMDGOALS)),)
+ export CHECK_DTBS=y
+ dtbs: dt_binding_check
+ endif
+-- 
+2.33.1
+

--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.16.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.16.bb
@@ -1,0 +1,9 @@
+# Copyright (C) 2021 Linaro
+# Released under the MIT license (see COPYING.MIT for the terms)
+
+require recipes-kernel/linux/linux-linaro-qcom.inc
+
+COMPATIBLE_MACHINE = "(sa8155p)"
+SRC_URI:append = " file://0001-Revert-kbuild-Enable-DT-schema-checks-for-.dtb-targe.patch"
+SRCBRANCH = "release/sa8155p-adp/qcomlt-5.16"
+SRCREV = "8f6679c37887846aa2e284b068e85967ef0b48c7"


### PR DESCRIPTION
Create a new .bb file for honister buils for sa8155p adp board
which already supports kernel version 5.16.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>