### PR TITLE
layers: Bump to use kirkstone

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PATTERN_qcom := "^${LAYERDIR}/"
 BBFILE_PRIORITY_qcom = "5"
 
 LAYERDEPENDS_qcom = "core"
-LAYERSERIES_COMPAT_qcom = "honister"
+LAYERSERIES_COMPAT_qcom = "kirkstone"
 
 BBFILES_DYNAMIC += " \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bb \


### PR DESCRIPTION
its not going to be backward ABI compatible with honister due to variable renaming.

Signed-off-by: Khem Raj <raj.khem@gmail.com>