### PR TITLE
recipes-kernel: Move sa8155p-adp receipe to point to stable 5.15

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
@@ -6,5 +6,6 @@ require recipes-kernel/linux/linux-linaro-qcom.inc
 # SRCBRANCH set to "release/qcomlt-5.15" in linux-linaro-qcom.inc
 SRCREV = "9bc25b368335b6d3d59be44db0c4818bdfbfa546"
 
-SRCBRANCH:sa8155p = "release/sa8155p-adp/qcomlt-5.15"
-SRCREV:sa8155p = "3290018e72cdf6a1b90e672710ad2a6dda9fffd6"
+# SRCBRANCH set to adp stable release branch
+SRCBRANCH:sa8155p = "release/sa8155p-adp/v5.15.y"
+SRCREV:sa8155p = "0250bf9019f7f6fe5e8e5fdb956643af630cfa94"

--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.16.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.16.bb
@@ -1,9 +1,0 @@
-# Copyright (C) 2021 Linaro
-# Released under the MIT license (see COPYING.MIT for the terms)
-
-require recipes-kernel/linux/linux-linaro-qcom.inc
-
-COMPATIBLE_MACHINE = "(sa8155p)"
-SRC_URI:append = " file://0001-Revert-kbuild-Enable-DT-schema-checks-for-.dtb-targe.patch"
-SRCBRANCH = "release/sa8155p-adp/qcomlt-5.16"
-SRCREV = "8ea62eb83b9da1402d505146c529bcca87b7ba80"


### PR DESCRIPTION
Since honister is replacing dunfell as the more recent
stable branch, this change moves sa8155p-adp to the stable
kernel version 5.15.y and removes the 5.16 receipe.

Going forward, for sa8155p-adp board:
 - dunfell would support 5.15.y stable kernel version, and
 - honister would support kernel versions which are closer to
   linus's tip.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>