### PR TITLE
linux-linaro-qcom,lava-test-shell: Use SPDX naming convention for LIC…

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcom.inc
+++ b/recipes-kernel/linux/linux-linaro-qcom.inc
@@ -3,7 +3,7 @@
 # Released under the MIT license (see COPYING.MIT for the terms)
 
 DESCRIPTION ??= "Linaro Qualcomm Landing team ${PV} Kernel"
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://COPYING;md5=6bc538ed5bd9a7fc9398086aedcd7e46"
 
 inherit kernel

--- a/recipes-test/lava-test-shell/lava-test-shell.bb
+++ b/recipes-test/lava-test-shell/lava-test-shell.bb
@@ -1,7 +1,7 @@
 SUMMARY = "Lava test shell helpers"
 SECTION = "test"
 
-LICENSE = "GPLv2"
+LICENSE = "GPL-2.0-only"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 SRCREV = "dcf554ef9b89c74d028734c74edea1ef5e777d33"


### PR DESCRIPTION
…ENSE

Signed-off-by: Khem Raj <raj.khem@gmail.com>