### PR TITLE
linux: Update SRCREV for release/sa8155p-adp/qcomlt-5.15

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
@@ -8,4 +8,4 @@ SRCREV = "9bc25b368335b6d3d59be44db0c4818bdfbfa546"
 
 # SRCBRANCH set to adp stable release branch
 SRCBRANCH:sa8155p = "release/sa8155p-adp/v5.15.y"
-SRCREV:sa8155p = "06b5426d830116835313e4ffd8c175380ae2cadc"
+SRCREV:sa8155p = "2ba0a8b57f45702b778000dfec877118006cab05"


### PR DESCRIPTION
Update the SRCREV in linux-linaro-qcomlt_5.15.bb file
for sa8155p adp board, which points to support for the following
new kernel features:
 - PCIe0 in RC mode,
 - LmH regulator,
 - Crypto Engine support.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>