### PR TITLE
Remove RB5 DVT support

### DIFF
--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -9,7 +9,7 @@ EXTRA_IMAGECMD:ext4 += " -b 4096 "
 # Support for dragonboard{410, 820, 845}c, rb5
 KERNEL_IMAGETYPE ?= "Image.gz"
 SERIAL_CONSOLE ?= "115200 ttyMSM0"
-KERNEL_DEVICETREE ?= "qcom/apq8016-sbc.dtb qcom/apq8096-db820c.dtb qcom/sdm845-db845c.dtb qcom/qrb5165-rb5.dtb qcom/sm8250-rb5-dvt.dtb"
+KERNEL_DEVICETREE ?= "qcom/apq8016-sbc.dtb qcom/apq8096-db820c.dtb qcom/sdm845-db845c.dtb qcom/qrb5165-rb5.dtb"
 
 QCOM_BOOTIMG_PAGE_SIZE[apq8016-sbc] = "2048"
 QCOM_BOOTIMG_ROOTFS = "/dev/sda1"

--- a/conf/machine/qrb5165-rb5.conf
+++ b/conf/machine/qrb5165-rb5.conf
@@ -7,7 +7,7 @@ require conf/machine/include/qcom-sm8250.inc
 MACHINE_FEATURES = "usbhost usbgadget alsa screen wifi bluetooth ext2"
 
 KERNEL_IMAGETYPE ?= "Image.gz"
-KERNEL_DEVICETREE ?= "qcom/qrb5165-rb5.dtb qcom/sm8250-rb5-dvt.dtb"
+KERNEL_DEVICETREE ?= "qcom/qrb5165-rb5.dtb"
 KERNEL_CMDLINE_EXTRA ?= "pcie_pme=nomsi"
 
 SERIAL_CONSOLE ?= "115200 ttyMSM0"


### PR DESCRIPTION
Mainline kernels do not provide `sm8250-rb5-dvt.dts`. Drop it from the default configuration. If necessary, this DTS can supported in `linux-linaro-qcom.inc`.