### PR TITLE
Linux mainline support

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -17,4 +17,6 @@ BBFILES_DYNAMIC += " \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bbappend \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bb \
     networking-layer:${LAYERDIR}/dynamic-layers/networking-layer/*/*/*.bbappend \
+    meta-linux-mainline:${LAYERDIR}/dynamic-layers/meta-linux-mainline/*/*/*.bb \
+    meta-linux-mainline:${LAYERDIR}/dynamic-layers/meta-linux-mainline/*/*/*.bbappend \
 "

--- a/dynamic-layers/meta-linux-mainline/recipes-kernel/linux/linux-mainline.bbappend
+++ b/dynamic-layers/meta-linux-mainline/recipes-kernel/linux/linux-mainline.bbappend
@@ -1,0 +1,1 @@
+include linux-mainline.inc

--- a/dynamic-layers/meta-linux-mainline/recipes-kernel/linux/linux-mainline.inc
+++ b/dynamic-layers/meta-linux-mainline/recipes-kernel/linux/linux-mainline.inc
@@ -1,0 +1,4 @@
+require recipes-kernel/linux/linux-qcom-bootimg.inc
+
+KBUILD_DEFCONFIG:qcom = "defconfig"
+KBUILD_DEFCONFIG:qcom:arm = "qcom_defconfig"

--- a/dynamic-layers/meta-linux-mainline/recipes-kernel/linux/linux-stable_%.bbappend
+++ b/dynamic-layers/meta-linux-mainline/recipes-kernel/linux/linux-stable_%.bbappend
@@ -1,0 +1,1 @@
+include linux-mainline.inc


### PR DESCRIPTION
Add support for kernels from `meta-linux-mainline`. This allows using `linux-mainline` and `linux-stable` as providers for `virtual/kernel`.