### PR TITLE
Install modules into rootfs

### DIFF
--- a/recipes-kernel/images/initramfs-rootfs-image.bb
+++ b/recipes-kernel/images/initramfs-rootfs-image.bb
@@ -2,6 +2,7 @@ DESCRIPTION = "Ramdisk image for pivoting into rootfs"
 
 PACKAGE_INSTALL = " \
     base-passwd \
+    initramfs-module-copy-modules \
     initramfs-module-rootfs \
     initramfs-module-udev \
     ${VIRTUAL-RUNTIME_base-utils} \

--- a/recipes-support/initrdscripts/files/copy-modules.sh
+++ b/recipes-support/initrdscripts/files/copy-modules.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# Copyright (C) 2022 Linaro Ltd.
+# Licensed on MIT
+
+copy_modules_enabled() {
+	[ -n "${bootparam_copy_modules}" -a -d /lib/modules/`uname -r` ]
+}
+
+copy_modules_run() {
+	if [ -n "$ROOTFS_DIR" ]; then
+		rm -rf $ROOTFS_DIR/lib/modules/`uname -r`
+		mkdir -p $ROOTFS_DIR/lib/modules
+		cp -a /lib/modules/`uname -r` $ROOTFS_DIR/lib/modules
+	else
+		debug "No rootfs has been set"
+	fi
+}

--- a/recipes-support/initrdscripts/initramfs-module-copy-modules_1.0.bb
+++ b/recipes-support/initrdscripts/initramfs-module-copy-modules_1.0.bb
@@ -1,0 +1,15 @@
+SUMMARY = "initramfs-framework module for copying kernel modules from initramfs to rootfs"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COREBASE}/meta/COPYING.MIT;md5=3da9cfbcb788c80a0384361b4de20420"
+RDEPENDS:${PN} = "initramfs-framework-base ${VIRTUAL-RUNTIME_base-utils}"
+
+SRC_URI = "file://copy-modules.sh"
+
+S = "${WORKDIR}"
+
+do_install() {
+    install -d ${D}/init.d
+    install -m 0755 ${WORKDIR}/copy-modules.sh ${D}/init.d/95-copy_modules
+}
+
+FILES:${PN} = "/init.d/"


### PR DESCRIPTION
Add an initramfs module that will copy modules from initramfs to the rootfs. To enable it, add 'copy_modules' kernel bootarg.