### PR TITLE
initramfs-rootfs-image: exclude all kernel images from the image

### DIFF
--- a/recipes-kernel/images/initramfs-rootfs-image.bb
+++ b/recipes-kernel/images/initramfs-rootfs-image.bb
@@ -20,3 +20,6 @@ inherit core-image
 
 IMAGE_ROOTFS_SIZE = "8192"
 IMAGE_ROOTFS_EXTRA_SPACE = "0"
+
+# Exclude all kernel images from the rootfs
+PACKAGE_EXCLUDE = "kernel-image-*"


### PR DESCRIPTION
Exclude all the kernel images from this initramfs. This shrinks the
initramfs for a few megs.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>