### PR TITLE
firmware-qcom-dragonboard820c: package modem firmware

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-dragonboard820c_01700.1.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard820c_01700.1.bb
@@ -31,6 +31,10 @@ do_install() {
 
     install -m 0444 ./bootloaders-linux/adspso.bin ${D}${FW_QCOM_PATH}/
 
+    install -m 0444 ./proprietary-linux/mba*.* ${D}${FW_QCOM_PATH}/
+    install -m 0444 ./proprietary-linux/modem*.* ${D}${FW_QCOM_PATH}/
+    pil-squasher ${D}${FW_QCOM_PATH}/modem.mbn ./proprietary-linux/modem.mdt
+
     install -d ${D}${nonarch_base_libdir}/firmware/ath10k/QCA6174/hw3.0/
     install -m 0444 ${S}/board-2.bin ${D}${nonarch_base_libdir}/firmware/ath10k/QCA6174/hw3.0/board-2.bin
 
@@ -55,6 +59,8 @@ SPLIT_FIRMWARE_PACKAGES = " \
     ${PN}-dspso \
     linux-firmware-qcom-${FW_QCOM_NAME}-audio \
     linux-firmware-qcom-${FW_QCOM_NAME}-audio-split \
+    linux-firmware-qcom-${FW_QCOM_NAME}-modem \
+    linux-firmware-qcom-${FW_QCOM_NAME}-modem-split \
     ${PN}-split \
 "
 


### PR DESCRIPTION
Add packages with modem firmware (mba.mbn, modem.mbn, modem.*).
It is confirmed that the modem boots on db820c. GNSS is still not
working.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>