### PR TITLE
linux: Update SRCREV for release/sa8155p-adp/qcomlt-5.15

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
@@ -8,4 +8,4 @@ SRCREV = "9bc25b368335b6d3d59be44db0c4818bdfbfa546"
 
 # SRCBRANCH set to adp stable release branch
 SRCBRANCH:sa8155p = "release/sa8155p-adp/v5.15.y"
-SRCREV:sa8155p = "56d9373fe4fea60785d82544bca5b73aace711b3"
+SRCREV:sa8155p = "a10c25c46f3ac4ac2a67aa63620e471d61812968"


### PR DESCRIPTION
Update the SRCREV in linux-linaro-qcomlt_5.15.bb file
for sa8155p adp board, to fix the ADMA error seen while
using microSD card connected to SDC2, because of the
incorrect sid value.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>