### PR TITLE
linux: Update SRCREV for release/sa8155p-adp/qcomlt-5.15

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
@@ -8,4 +8,4 @@ SRCREV = "9bc25b368335b6d3d59be44db0c4818bdfbfa546"
 
 # SRCBRANCH set to adp stable release branch
 SRCBRANCH:sa8155p = "release/sa8155p-adp/v5.15.y"
-SRCREV:sa8155p = "a10c25c46f3ac4ac2a67aa63620e471d61812968"
+SRCREV:sa8155p = "e9c01bf9f7b58369047a25f8490ea03557554cf1"


### PR DESCRIPTION
Update the SRCREV in linux-linaro-qcomlt_5.15.bb file
for sa8155p adp board, to fix the issues seen with ethernet
traffic getting stalled on SA8155p-ADP board with default (or larger)
mtu size of 1500 bytes, by disabling multiple Tx and Rx queues
for the ethernet IP.

With the single queue setup, the ethernet traffic is very stable
and no observable degradation in performance is seen as well.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>