### PR TITLE
initramfs-test-image: enable gpsd support

### DIFF
--- a/recipes-test/images/initramfs-test-full-image.bb
+++ b/recipes-test/images/initramfs-test-full-image.bb
@@ -24,15 +24,21 @@ PACKAGE_INSTALL:append:libc-glibc = " \
 # We'd like to include extra packages provided by layers which we do not depend
 # on. This can be handled by .bbappends, but then image recipes including this
 # one would not get all these tools. So simulate dynamic bbappend here.
+
+# ncurses-terminfo is provided by oe-core layer, but it's only needed for gps (cgps), so include it here
 PACKAGE_INSTALL_openembedded-layer += " \
     crash \
     dhrystone \
+    gpsd \
+    gpsd-machine-conf \
+    gps-utils \
     iozone3 \
     libgpiod \
     libgpiod-tools \
     lmbench \
     makedumpfile \
     mbw \
+    ncurses-terminfo-base \
     sysbench \
     tinymembench \
     tiobench \


### PR DESCRIPTION
Bundle gpsd and gps-utils into initramfs-test-image. This cause
compressed image growth of 1.6 MiB.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>