### PR TITLE
initramfs-firmware-image: remove kernel dependency

### DIFF
--- a/recipes-test/images/initramfs-firmware-image.bb
+++ b/recipes-test/images/initramfs-firmware-image.bb
@@ -1,5 +1,9 @@
 DESCRIPTION = "Tiny ramdisk image with firmware files"
 
+# We do not use kernel image or kernel modules in the image, so remove the
+# dependency on the kernel
+KERNELDEPMODDEPEND = ""
+
 # Do not install anything by default
 PACKAGE_INSTALL = ""
 


### PR DESCRIPTION
As initramfs-firmware-image doesn't use the kernel modules, break the
dependency by setting KERNELDEPMODDEPEND to the empty strings.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>