### PR TITLE
initramfs-test-image: Add a few utils

### DIFF
--- a/recipes-test/images/initramfs-test-image.bb
+++ b/recipes-test/images/initramfs-test-image.bb
@@ -7,6 +7,7 @@ PACKAGE_INSTALL += " \
     alsa-utils-amixer \
     alsa-utils-aplay \
     alsa-utils-speakertest \
+    cmake \
     bluez5 \
     dhcpcd \
     diag \
@@ -18,12 +19,14 @@ PACKAGE_INSTALL += " \
     e2fsprogs-tune2fs \
     ethtool \
     fastrpc \
+    git \
     gptfdisk \
     i2c-tools \
     iw \
     lava-test-shell \
     libdrm-tests \
     lrzsz \
+    make \
     pciutils \
     pd-mapper \
     qrtr \


### PR DESCRIPTION
Add the following utilities to 'initramfs-test-image'
to allow easier board development:

- cmake
- make
- git

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>