### PR TITLE
initramfs-test-image: enable read-edid package

### DIFF
--- a/recipes-test/images/initramfs-test-image.bb
+++ b/recipes-test/images/initramfs-test-image.bb
@@ -46,6 +46,7 @@ PACKAGE_INSTALL_openembedded-layer += " \
     devmem2 \
     lmsensors-config-libsensors \
     lmsensors-sensors \
+    read-edid \
 "
 
 PACKAGE_INSTALL_networking-layer += " \


### PR DESCRIPTION
To assist in checking EDID reads and modesetting enable the read-edid
package. The image growth is 9 KiB.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>