### PR TITLE
linux: Update SRCREV for release/sa8155p-adp/qcomlt-5.15

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
@@ -8,4 +8,4 @@ SRCREV = "9bc25b368335b6d3d59be44db0c4818bdfbfa546"
 
 # SRCBRANCH set to adp stable release branch
 SRCBRANCH:sa8155p = "release/sa8155p-adp/v5.15.y"
-SRCREV:sa8155p = "e9c01bf9f7b58369047a25f8490ea03557554cf1"
+SRCREV:sa8155p = "3ba78006ff85754fa26e622f78cefa11971b3df2"


### PR DESCRIPTION
Update the SRCREV in linux-linaro-qcomlt_5.15.bb file
for sa8155p adp board, to add support for smcinvoke
and a couple of important UFS fixes (for hibernation / resume
issues) as well.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>