### PR TITLE
linux: update kernel for SA8155P-ADP

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
@@ -8,4 +8,4 @@ SRCREV = "9bc25b368335b6d3d59be44db0c4818bdfbfa546"
 
 # SRCBRANCH set to adp stable release branch
 SRCBRANCH:sa8155p = "release/sa8155p-adp/v5.15.y"
-SRCREV:sa8155p = "e9c01bf9f7b58369047a25f8490ea03557554cf1"
+SRCREV:sa8155p = "090854301b471d60d4de4402c9c80bf46950f39a"


### PR DESCRIPTION
The following changes were backported from upstream:

090854301b471 scsi: ufs: ufs-qcom: Enter and exit hibern8 during clock scaling
adb54728a7a08 scsi: ufs: core: Export hibern8 entry and exit functions

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>