### PR TITLE
Fix alternative wcn6855 firmware packaging

### DIFF
--- a/recipes-bsp/firmware/firmware-wcn6855_git.bb
+++ b/recipes-bsp/firmware/firmware-wcn6855_git.bb
@@ -19,14 +19,25 @@ do_compile() {
 	:
 }
 
-FWDIR = "${nonarch_base_libdir}/firmware"
-SUBDIR = "ath11k/WCN6855/hw2.0"
+FWDIR = "${nonarch_base_libdir}/firmware/ath11k/WCN6855/hw2.0"
+FWDIR21 = "${nonarch_base_libdir}/firmware/ath11k/WCN6855/hw2.1"
 
 do_install() {
-    install -d ${D}${FWDIR}/${SUBDIR}
+    install -d ${D}${FWDIR}
 
-    install -m 0644 ${SUBDIR}/* ${D}${FWDIR}/${SUBDIR}
+    install -m 0644 ath11k/WCN6855/hw2.0/* ${D}${FWDIR}
+
+    install -d ${D}${FWDIR21}
+    ln -sr ${D}${FWDIR}/board.bin ${D}${FWDIR21}/
 }
+
+inherit update-alternatives
+
+ALTERNATIVE:${PN} += "wcn6855-hw20-amss wcn6855-hw20-m3 wcn6855-hw20-regdb"
+ALTERNATIVE_LINK_NAME[wcn6855-hw20-amss] = "${nonarch_base_libdir}/firmware/ath11k/WCN6855/hw2.0/amss.bin"
+ALTERNATIVE_LINK_NAME[wcn6855-hw20-m3] = "${nonarch_base_libdir}/firmware/ath11k/WCN6855/hw2.0/m3.bin"
+ALTERNATIVE_LINK_NAME[wcn6855-hw20-regdb] = "${nonarch_base_libdir}/firmware/ath11k/WCN6855/hw2.0/regdb.bin"
+ALTERNATIVE_PRIORITY = "100"
 
 PACKAGE_BEFORE_PN = "${PN}-board"
 
@@ -34,7 +45,7 @@ RDEPENDS:${PN}-board += "${PN}"
 RDEPENDS:${PN} += "linux-firmware-ath10k-license"
 
 FILES:${PN} = "${FWDIR}"
-FILES:${PN}-board = "${FWDIR}/${SUBDIR}/board*.bin ${FWDIR}/${SUBDIR}/regdb*bin"
+FILES:${PN}-board = "${FWDIR}/board*.bin ${FWDIR21}/board*.bin"
 
 # Firmware files are generally not ran on the CPU, so they can be
 # allarch despite being architecture specific

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -7,3 +7,10 @@ inherit ${ALTERNATIVES_CLASS}
 # firmware-ath6kl provides updated bdata.bin, which can not be accepted into main linux-firmware repo
 ALTERNATIVE:${PN}-ath6k:qcom = "ar6004-hw13-bdata"
 ALTERNATIVE_LINK_NAME[ar6004-hw13-bdata] = "${nonarch_base_libdir}/firmware/ath6k/AR6004/hw1.3/bdata.bin"
+
+ALTERNATIVE:${PN}-ath11k:qcom += "wcn6855-hw20-amss wcn6855-hw20-m3 wcn6855-hw20-regdb wcn6855-hw20-notice wcn6855-hw20-board-2"
+ALTERNATIVE_LINK_NAME[wcn6855-hw20-amss] = "${nonarch_base_libdir}/firmware/ath11k/WCN6855/hw2.0/amss.bin"
+ALTERNATIVE_LINK_NAME[wcn6855-hw20-m3] = "${nonarch_base_libdir}/firmware/ath11k/WCN6855/hw2.0/m3.bin"
+ALTERNATIVE_LINK_NAME[wcn6855-hw20-regdb] = "${nonarch_base_libdir}/firmware/ath11k/WCN6855/hw2.0/regdb.bin"
+ALTERNATIVE_LINK_NAME[wcn6855-hw20-notice] = "${nonarch_base_libdir}/firmware/ath11k/WCN6855/hw2.0/Notice.txt"
+ALTERNATIVE_LINK_NAME[wcn6855-hw20-board-2] = "${nonarch_base_libdir}/firmware/ath11k/WCN6855/hw2.0/board-2.bin"

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,4 +1,9 @@
-inherit update-alternatives
+# To make the layer pass yocto-check-layer only inherit update-alternatives when building for qualcomm
+ALTERNATIVES_CLASS = ""
+ALTERNATIVES_CLASS:qcom = "update-alternatives"
 
-ALTERNATIVE:${PN}-ath6k = "ar6004-hw13-bdata"
+inherit ${ALTERNATIVES_CLASS}
+
+# firmware-ath6kl provides updated bdata.bin, which can not be accepted into main linux-firmware repo
+ALTERNATIVE:${PN}-ath6k:qcom = "ar6004-hw13-bdata"
 ALTERNATIVE_LINK_NAME[ar6004-hw13-bdata] = "${nonarch_base_libdir}/firmware/ath6k/AR6004/hw1.3/bdata.bin"

--- a/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
+++ b/recipes-kernel/linux-firmware/linux-firmware_%.bbappend
@@ -1,4 +1,4 @@
 inherit update-alternatives
 
-ALTERNATIVE:${PN} = "ar6004-hw13-bdata"
+ALTERNATIVE:${PN}-ath6k = "ar6004-hw13-bdata"
 ALTERNATIVE_LINK_NAME[ar6004-hw13-bdata] = "${nonarch_base_libdir}/firmware/ath6k/AR6004/hw1.3/bdata.bin"


### PR DESCRIPTION
Firmware from linux-firmware has issues on sm8450/wcn6856 platforms
(inability to load board file). Allow installing alternative firmware
files.