### PR TITLE
README: update OE core and meta-openembedded URIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ OpenEmbedded/Yocto Project layer for Qualcomm based platforms.
 This layer depends on:
 
 ```
-URI: git://github.com/openembedded/oe-core.git
+URI: https://github.com/openembedded/oe-core.git
 layers: meta
 branch: master
 revision: HEAD
@@ -16,7 +16,7 @@ revision: HEAD
 This layers has an optional dependency on meta-oe layer:
 
 ```
-URI: git://github.com/openembedded/meta-openembedded.git
+URI: https://github.com/openembedded/meta-openembedded.git
 layers: meta-oe
 branch: master
 revision: HEAD

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ OpenEmbedded/Yocto Project layer for Qualcomm based platforms.
 This layer depends on:
 
 ```
-URI: https://github.com/openembedded/oe-core.git
+URI: https://github.com/openembedded/openembedded-core.git
 layers: meta
 branch: master
 revision: HEAD


### PR DESCRIPTION
The URIs provided in the README are not working anymore because:
* the unencrypted git protocol support has been removed from github [0]
* the OE core repository has changed name

This PR updates the README in order to provide valid URIs.

[0] https://github.blog/2021-09-01-improving-git-protocol-security-github/