### PR TITLE
linux: update kernel for SA8155P-ADP

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
@@ -8,4 +8,4 @@ SRCREV = "9bc25b368335b6d3d59be44db0c4818bdfbfa546"
 
 # SRCBRANCH set to adp stable release branch
 SRCBRANCH:sa8155p = "release/sa8155p-adp/v5.15.y"
-SRCREV:sa8155p = "090854301b471d60d4de4402c9c80bf46950f39a"
+SRCREV:sa8155p = "8858667d191132c5f71b4436ef2c7c29a140fc16"


### PR DESCRIPTION
The following changes were added to the SA8155p v5.15.y kernel branch:

8858667d1911 ("DON'T UPSTREAM: smcinvoke: allow invoke commands without arguments")
877b2bc482b9 ("DON'T UPSTREAM: arm64: configs/defconfig: Enable QCOM_SMCINVOKE")
0c2f66b76632 ("DON'T UPSTREAM: arm64: dts: sm8150: add smcinvoke node")
289fc23cca12 ("DON'T UPSTREAM: soc: qcom: Introduce smc invoke driver")
09c49793cf10 ("DON'T UPSTREAM: firmware: qcom_scm: Add invoke and callback commands for smc invoke")

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>