### PR TITLE
linux: update kernel for SA8155P-ADP

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
@@ -8,4 +8,4 @@ SRCREV = "9bc25b368335b6d3d59be44db0c4818bdfbfa546"
 
 # SRCBRANCH set to adp stable release branch
 SRCBRANCH:sa8155p = "release/sa8155p-adp/v5.15.y"
-SRCREV:sa8155p = "8858667d191132c5f71b4436ef2c7c29a140fc16"
+SRCREV:sa8155p = "f721c52e0d32f1f4f765dbddf125cae331f75bf7"


### PR DESCRIPTION
The following changes were added to the SA8155p v5.15.y kernel branch:

010e8860f5c2 ("DON'T UPSTREAM: arm64: dts: qcom: qcs8155p-adp: Add 'msm-id' and 'msm-name'")
5c1facaaf52b ("DON'T UPSTREAM: arm64: dts: qcom: sa8155p-adp: Add 'msm-id' and 'msm-name'")
c9cf083aea66 ("DON'T UPSTREAM: dt-bindings: arm: qcom: Add compatible for QCS8155p-adp board")
c286773792c7 ("DON'T UPSTREAM: arm64: dts: qcom: qcs8155p-adp: Add base dts file")

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>