### PR TITLE
conf/sa8155p-adp.conf: Add support for building qcs8155p-adp dtb

### DIFF
--- a/conf/machine/sa8155p-adp.conf
+++ b/conf/machine/sa8155p-adp.conf
@@ -1,13 +1,13 @@
 #@TYPE: Machine
 #@NAME: SA8155P-ADP
-#@DESCRIPTION: Machine configuration for the SA8155P-ADP development board, with Qualcomm Snapdragon 855 SM8150.
+#@DESCRIPTION: Machine configuration for the SA8155P-ADP / QCS8155-ADP development board, with Qualcomm Snapdragon SA8155p / QCS8155p.
 
 require conf/machine/include/qcom-sa8155p.inc
 
 MACHINE_FEATURES = "usbhost usbgadget ext2"
 
 KERNEL_IMAGETYPE ?= "Image.gz"
-KERNEL_DEVICETREE ?= "qcom/sa8155p-adp.dtb"
+KERNEL_DEVICETREE ?= "qcom/sa8155p-adp.dtb qcom/qcs8155p-adp.dtb"
 
 SERIAL_CONSOLE ?= "115200 ttyMSM0"
 


### PR DESCRIPTION
Add support for building qcs8155p-adp dtb.
Basically both the sa8155p-adp and qcs8155p-adp boards
use the same adp motherboard but have different
SoC daughter cards mounted on the adp motherboard
respectively.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>