### PR TITLE
packagegroup-firmware-dragonboard820c: add missing dependencies

### DIFF
--- a/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard820c.bb
+++ b/recipes-bsp/packagegroups/packagegroup-firmware-dragonboard820c.bb
@@ -7,5 +7,7 @@ RRECOMMENDS:${PN} += " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', 'linux-firmware-qcom-adreno-a530', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'wifi', 'linux-firmware-ath10k', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'linux-firmware-qca', '', d)} \
+    linux-firmware-qcom-apq8096-audio \
+    linux-firmware-qcom-apq8096-modem \
     linux-firmware-qcom-venus-4.2 \
 "


### PR DESCRIPTION
Add dependencies on APQ8096's aDSP and modem firmware.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>