### PR TITLE
firmware-qcom-dragonboard845c: drop WiFi board-2.bin file

### DIFF
--- a/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
+++ b/recipes-bsp/firmware/firmware-qcom-dragonboard845c_20190529180356-v4.bb
@@ -7,15 +7,6 @@ SRC_URI = "https://releases.linaro.org/96boards/dragonboard845c/qualcomm/firmwar
 SRC_URI[md5sum] = "ad69855a1275547b16d94a1b5405ac62"
 SRC_URI[sha256sum] = "4289d2f2a7124b104d0274879e702aae9b1e50c42eec3747f8584c6744ef65e3"
 
-inherit allarch
-DEPENDS += "qca-swiss-army-knife-native"
-inherit python3native
-
-do_compile() {
-    # Build board-2.bin needed by WiFi
-    ath10k-generate-board-2_json.sh ./38-bdwlan_split board-2.json
-    python3 "${STAGING_BINDIR_NATIVE}/ath10k-bdencoder" -c board-2.json -o board-2.bin
-}
 
 do_install() {
     install -d ${D}${nonarch_base_libdir}/firmware/
@@ -27,9 +18,6 @@ do_install() {
     install -m 0444 ./18-adreno-fw/a630_zap*.* ${D}${nonarch_base_libdir}/firmware/qcom/
     install -m 0444 ./20-adsp_split/firmware/adsp*.* ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
     install -m 0444 ./21-cdsp_split/firmware/cdsp*.* ${D}${nonarch_base_libdir}/firmware/qcom/sdm845
-
-    install -d ${D}${nonarch_base_libdir}/firmware/ath10k/WCN3990/hw1.0/
-    install -m 0444 ./board-2.bin ${D}${nonarch_base_libdir}/firmware/ath10k/WCN3990/hw1.0/
 
     install -d ${D}${sysconfdir}/
     install -m 0644 LICENSE.qcom.txt ${D}${sysconfdir}/QCOM-LINUX-BOARD-SUPPORT-LICENSE-${PN}


### PR DESCRIPTION
Drop board-2.bin file, board data has been merged into linux-firmware.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
(cherry picked from commit 6c366240e681a102a94522e86bab322cf3ac3ebc)