### PR TITLE
kirkstone: linux: Create 5.19 kernel based recipe for sa8155p adp

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.19.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.19.bb
@@ -1,0 +1,5 @@
+require recipes-kernel/linux/linux-linaro-qcom.inc
+
+COMPATIBLE_MACHINE = "(sa8155p)"
+SRCBRANCH = "sa8155p-adp/qcomlt-track-upstream"
+SRCREV = "ecd82903edb65c18195c83e697cfcfd0815cf02a"


### PR DESCRIPTION
Create 5.19 kernel based recipe for sa8155p adp
board. The rational behind the same is that
kirkstone support for sa8155p adp board would always
try to follow the latest upstream kernel version.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>