### PR TITLE
linux: update kernel for SA8155P-ADP

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
@@ -8,4 +8,4 @@ SRCREV = "9bc25b368335b6d3d59be44db0c4818bdfbfa546"
 
 # SRCBRANCH set to adp stable release branch
 SRCBRANCH:sa8155p = "release/sa8155p-adp/v5.15.y"
-SRCREV:sa8155p = "9e6eb1ce16ca0b97949ff51aeaa6168a28fef216"
+SRCREV:sa8155p = "fa4cb057efc240f14cbf43b23d7e23b521a83dfe"


### PR DESCRIPTION
The following changes were added to the SA8155p v5.15.y kernel branch:

 a4cb057efc2 ("FROMGIT: arm64: dts: qcom: qrb5165-rb5: declare tri-led user leds")
 5e48777272fa ("FROMGIT: arm64: dts: qcom: pm8150l: add Light Pulse Generator device node")
 fc1aa66370d5 ("FROMGIT: arm64: dts: qcom: pm8150b: add Light Pulse Generator device node")
 c8b2da3ca808 ("UPSTREAM: leds: Add driver for Qualcomm LPG")
 d04a88aab42e ("UPSTREAM: dt-bindings: leds: Add Qualcomm Light Pulse Generator binding")
 93d00ec71c6c ("FROMLIST: thermal: qcom: tsens: Implement re-initialization workaround quirk")
 60221c4ddf4e ("FROMLIST: thermal: qcom: tsens: Add support for 'needs_reinit_wa' for sm8150")
 e7c207c948cf ("FROMLIST: firmware: qcom_scm: Add support for tsens reinit workaround")

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>