### PR TITLE
master: linux: Create 5.19 kernel based recipe for sa8155p adp

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.19.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.19.bb
@@ -1,0 +1,5 @@
+require recipes-kernel/linux/linux-linaro-qcom.inc
+
+COMPATIBLE_MACHINE = "(sa8155p)"
+SRCBRANCH = "sa8155p-adp/qcomlt-5.19"
+SRCREV = "df58efb44dbb5cc8d041c57c506046e881239cc4"


### PR DESCRIPTION
Create 5.19 kernel based recipe for sa8155p adp
board. The rational behind the same is that
master support for sa8155p adp board would always
try to support the latest upstream kernel version
tested on the board.

So, while by default the releases for adp will still
be based on '5.15 + OE dunfell', the newer snapshots will
also be available based on '5.19 + OE master'.

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>