### PR TITLE
qcom-common.inc: drop legacy/obsolete xf86-input drivers

### DIFF
--- a/conf/machine/include/qcom-common.inc
+++ b/conf/machine/include/qcom-common.inc
@@ -11,8 +11,6 @@ XSERVER ?= " \
     xserver-xorg-module-libint10 \
     ${@bb.utils.contains('DISTRO_FEATURES', 'opengl', '${XSERVER_OPENGL}', 'xf86-video-fbdev', d)} \
     xf86-input-evdev \
-    xf86-input-mouse \
-    xf86-input-keyboard \
 "
 
 PREFERRED_PROVIDER_virtual/egl ?= "mesa"


### PR DESCRIPTION
With the removal of xf86-input-keyboard recipe form oe-core, meta-qcom
now depends on the unavailable package. While we are at it, follow the
change applied in 2016 to oe-core and also drop xf86-input-mouse.
xf86-input-evdev and -libinput should handle everything instead.

Note: the oe-core has also dropped the -evdev driver, but I'd prefer to
be safe than sorry and leave it in place for now.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>