### PR TITLE
linux: update kernel for SA8155P-ADP

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
@@ -8,4 +8,4 @@ SRCREV = "9bc25b368335b6d3d59be44db0c4818bdfbfa546"
 
 # SRCBRANCH set to adp stable release branch
 SRCBRANCH:sa8155p = "release/sa8155p-adp/v5.15.y"
-SRCREV:sa8155p = "fa4cb057efc240f14cbf43b23d7e23b521a83dfe"
+SRCREV:sa8155p = "64ee2bb62b3dfec3d81729bebe4d5775bf969d07"


### PR DESCRIPTION
The following changes were added to the SA8155p v5.15.y kernel branch:
  64ee2bb62b3d ("FROMLIST: arm64: dts: qcom: Fix sm8150 fastrpc node - use correct iommu values")
  1a0ea35b6861 ("DON'T UPSTREAM: Revert "FROMLIST: arm64: dts: qcom: sa8155p-adp: Add support for uSD card"")
  1bf9aa9996f3 ("FROMLIST: coresight: etm4x: Fix crash observed on Qcom ETM parts with 'Low power override'")
  b9d96b77c2d9 ("DON'T UPSTREAM: arm64: dts: qcom: sa8155p: Fix msm-id and msm-name for sa8155p-adp board")

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>