### PR TITLE
pulseaudio: guard the qcom-specific workaround with 'qcom' override

### DIFF
--- a/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -1,3 +1,3 @@
-do_install:append() {
+do_install:qcom:append() {
 	sed -i "s|^load-module module-udev-detect|load-module module-udev-detect tsched=0|" ${D}${sysconfdir}/pulse/default.pa
 }


### PR DESCRIPTION
The override in the bbappend is Qualcomm-specific, it should not be
applied to other platforms, thus add the :qcom: override to prevent it
from being applied to other platforms.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>