### PR TITLE
qcom-armv7a: disable Sony Xperia Castor dtb

### DIFF
--- a/conf/machine/qcom-armv7a.conf
+++ b/conf/machine/qcom-armv7a.conf
@@ -25,7 +25,6 @@ KERNEL_DEVICETREE ?= " \
     qcom-apq8064-ifc6410.dtb \
     qcom-apq8084-ifc6540.dtb \
     qcom-msm8974-lge-nexus5-hammerhead.dtb \
-    qcom-msm8974-sony-xperia-castor.dtb \
 "
 
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
The dtb name for Castor has been changed upstream. Drop it for now,
to allow building all kernel versions.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>