### PR TITLE
pulseaudio: fix use of overrides

### DIFF
--- a/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -1,3 +1,3 @@
-do_install:qcom:append() {
+do_install:append:qcom() {
 	sed -i "s|^load-module module-udev-detect|load-module module-udev-detect tsched=0|" ${D}${sysconfdir}/pulse/default.pa
 }


### PR DESCRIPTION
Fixes e5a2eb2f4409 (pulseaudio: guard the qcom-specific workaround
with 'qcom' override).

The order of the overrides was incorrect resulting in build failures.

Reported-by: Leonardo Sandoval <leonardo.sandoval@linaro.org>
Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>