### PR TITLE
linux: update kernel for SA8155P-ADP

### DIFF
--- a/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt_5.15.bb
@@ -8,4 +8,4 @@ SRCREV = "9bc25b368335b6d3d59be44db0c4818bdfbfa546"
 
 # SRCBRANCH set to adp stable release branch
 SRCBRANCH:sa8155p = "release/sa8155p-adp/v5.15.y"
-SRCREV:sa8155p = "64ee2bb62b3dfec3d81729bebe4d5775bf969d07"
+SRCREV:sa8155p = "38b7066ac1084c74759f1314c54b5735a1e5031d"


### PR DESCRIPTION
The following changes were added to the SA8155p v5.15.y kernel branch: 6c978a5e2f8d ("DON'T UPSTREAM: arm64: dts: qcom: sa8155p-iot-v2-adp: Disable uSD card support") c2a624e5d4a2 ("FROMLIST: thermal: qcom: qmi_cooling: Add skeletal qmi cooling driver") 9b62b2706ae4 ("FROMLIST: thermal: qcom: Add Kconfig entry & compilation support for qmi cooling driver") 00cc5bc93492 ("FROMLIST: dt-bindings: thermal: Add qcom,qmi-tmd-device and qcom,tmd-device yaml bindings") 66e55b4f6fb2 ("FROMLIST: MAINTAINERS: Add entry for Qualcomm Cooling Driver") 36f5ae9e65fc ("FROMLIST: arm64: dts: qcom: sm8150: Add qmi cooling device nodes") a64debe83ff7 ("FROMLIST: arm64: dts: qcom: sa8155p-adp: Enable qmi cooling device") 7d26c5099f21 ("FROMLIST: arm64: defconfig: Enable Qualcomm QMI cooling device driver") 38b7066ac108 ("DON'T UPSTREAM: arm64: dts: qcom: sa8155p-adp & sa8155p-iot-v2-adp")

Signed-off-by: Bhupesh Sharma <bhupesh.sharma@linaro.org>