### PR TITLE
layer.conf: bump to langdale

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,7 +10,7 @@ BBFILE_PATTERN_qcom := "^${LAYERDIR}/"
 BBFILE_PRIORITY_qcom = "5"
 
 LAYERDEPENDS_qcom = "core"
-LAYERSERIES_COMPAT_qcom = "kirkstone"
+LAYERSERIES_COMPAT_qcom = "langdale"
 
 BBFILES_DYNAMIC += " \
     openembedded-layer:${LAYERDIR}/dynamic-layers/openembedded-layer/*/*/*.bb \


### PR DESCRIPTION
OE-core has switch from kirkstone to langdale.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>