### PR TITLE
Debugcc updates

### DIFF
--- a/recipes-devtools/debugcc/debugcc/0001-msm8996-add-block-names.patch
+++ b/recipes-devtools/debugcc/debugcc/0001-msm8996-add-block-names.patch
@@ -1,0 +1,33 @@
+From 658d2022e3a31c916deec1aa9e35a4affc5e3d05 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Fri, 23 Sep 2022 18:01:00 +0300
+Subject: [PATCH] msm8996: add block names
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+---
+ msm8996.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/msm8996.c b/msm8996.c
+index bde2a95707ef..aa86f8351351 100644
+--- a/msm8996.c
++++ b/msm8996.c
+@@ -72,6 +72,7 @@ static struct debug_mux gcc = {
+ static struct debug_mux mmss_cc = {
+ 	.phys = 0x8c0000,
+ 	.size = 0xb00c,
++	.block_name = "mmss",
+ 
+ 	.enable_reg = 0x900,
+ 	.enable_mask = BIT(16),
+@@ -112,6 +113,7 @@ static void cpu_postmeasure(struct debug_mux *mux)
+ static struct debug_mux cpu_cc = {
+ 	.phys = 0x09820000,
+ 	.size = 0x1000,
++	.block_name = "cpu",
+ 
+ 	.mux_reg = 0x78,
+ 	.mux_mask = 0xff << 8,
+-- 
+2.35.1
+

--- a/recipes-devtools/debugcc/debugcc/block/0001-debugcc-add-support-for-printing-clocks-from-a-singl.patch
+++ b/recipes-devtools/debugcc/debugcc/block/0001-debugcc-add-support-for-printing-clocks-from-a-singl.patch
@@ -1,0 +1,124 @@
+From 5155b40c8481767b4717944402897a461e322cc3 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Mon, 23 May 2022 11:08:37 +0300
+Subject: [PATCH 1/2] debugcc: add support for printing clocks from a single CC
+
+Add a way to print clocks related to a particular CC. Add -b option,
+which takes 'block' name: cam, disp, cpu, gpu, video. Pass "-b core" to
+limit debugcc to "core" (gcc) clocks.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+---
+ debugcc.c | 39 ++++++++++++++++++++++++++++++---------
+ debugcc.h |  3 +++
+ 2 files changed, 33 insertions(+), 9 deletions(-)
+
+diff --git a/debugcc.c b/debugcc.c
+index 04e7956e0f5c..07ca2579b48a 100644
+--- a/debugcc.c
++++ b/debugcc.c
+@@ -227,12 +227,26 @@ static const struct measure_clk *find_clock(const struct debugcc_platform *platf
+ 	return NULL;
+ }
+ 
+-static void list_clocks(const struct debugcc_platform *platform)
++static bool clock_from_block(const struct measure_clk *clk, const char *block_name)
++{
++	return  !block_name ||
++		(!clk->leaf && !strcmp(block_name, CORE_CC_BLOCK)) ||
++		(clk->leaf && clk->leaf->block_name && !strcmp(block_name, clk->leaf->block_name));
++}
++
++static void list_clocks_block(const struct debugcc_platform *platform, const char *block_name)
+ {
+ 	const struct measure_clk *clk;
+ 
+-	for (clk = platform->clocks; clk->name; clk++)
+-		printf("%s\n", clk->name);
++	for (clk = platform->clocks; clk->name; clk++) {
++		if (!clock_from_block(clk, block_name))
++			continue;
++
++		if (clk->leaf && clk->leaf->block_name)
++			printf("%-40s %s\n", clk->name, clk->leaf->block_name);
++		else
++			printf("%s\n", clk->name);
++	}
+ }
+ 
+ static int mmap_mux(int devmem, struct debug_mux *mux)
+@@ -279,8 +293,8 @@ static void usage(void)
+ {
+ 	const struct debugcc_platform **p;
+ 
+-	fprintf(stderr, "debugcc <-p platform> <-a | -l | clk>\n");
+-	fprintf(stderr, "<platform>-debugcc <-a | -l | clk>\n");
++	fprintf(stderr, "debugcc <-p platform> [-b blk] <-a | -l | clk>\n");
++	fprintf(stderr, "<platform>-debugcc [-b blk] <-a | -l | clk>\n");
+ 
+ 	fprintf(stderr, "available platforms:");
+ 	for (p = platforms; *p; p++)
+@@ -296,15 +310,19 @@ int main(int argc, char **argv)
+ 	const struct measure_clk *clk = NULL;
+ 	bool do_list_clocks = false;
+ 	bool all_clocks = false;
++	const char *block_name = NULL;
+ 	int devmem;
+ 	int opt;
+ 	int ret;
+ 
+-	while ((opt = getopt(argc, argv, "alp:")) != -1) {
++	while ((opt = getopt(argc, argv, "ab:lp:")) != -1) {
+ 		switch (opt) {
+ 		case 'a':
+ 			all_clocks = true;
+ 			break;
++		case 'b':
++			block_name = strdup(optarg);
++			break;
+ 		case 'l':
+ 			do_list_clocks = true;
+ 			break;
+@@ -324,7 +342,7 @@ int main(int argc, char **argv)
+ 	}
+ 
+ 	if (do_list_clocks) {
+-		list_clocks(platform);
++		list_clocks_block(platform, block_name);
+ 		exit(0);
+ 	}
+ 
+@@ -350,8 +368,11 @@ int main(int argc, char **argv)
+ 	if (clk) {
+ 		measure(clk);
+ 	} else {
+-		for (clk = platform->clocks; clk->name; clk++)
+-			measure(clk);
++		for (clk = platform->clocks; clk->name; clk++) {
++			if (clock_from_block(clk, block_name)) {
++				measure(clk);
++			}
++		}
+ 	}
+ 
+ 	return 0;
+diff --git a/debugcc.h b/debugcc.h
+index 5a51efdc2535..8f2ae4be6a44 100644
+--- a/debugcc.h
++++ b/debugcc.h
+@@ -33,9 +33,12 @@
+ 
+ #define BIT(x) (1 << (x))
+ 
++#define CORE_CC_BLOCK "core"
++
+ struct debug_mux {
+ 	unsigned long phys;
+ 	void *base;
++	const char *block_name;
+ 	size_t size;
+ 
+ 	unsigned int enable_reg;
+-- 
+2.35.1
+

--- a/recipes-devtools/debugcc/debugcc/block/0002-debugcc-add-block-names-to-all-platforms.patch
+++ b/recipes-devtools/debugcc/debugcc/block/0002-debugcc-add-block-names-to-all-platforms.patch
@@ -1,0 +1,152 @@
+From 3ab2316b733183890b52fcec4f34aee87376d297 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Mon, 23 May 2022 11:11:01 +0300
+Subject: [PATCH 2/2] debugcc: add block names to all platforms
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+---
+ sc8280xp.c | 2 ++
+ sdm845.c   | 5 +++++
+ sm8350.c   | 4 ++++
+ sm8450.c   | 4 ++++
+ 4 files changed, 15 insertions(+)
+
+diff --git a/sc8280xp.c b/sc8280xp.c
+index 2f0ef2a2cb69..ad10a9db96d3 100644
+--- a/sc8280xp.c
++++ b/sc8280xp.c
+@@ -61,6 +61,7 @@ static struct debug_mux gcc = {
+ static struct debug_mux disp0_cc = {
+ 	.phys = 0xaf00000,
+ 	.size = 0x20000,
++	.block_name = "disp0",
+ 
+ 	.enable_reg = 0x500c,
+ 	.enable_mask = BIT(0),
+@@ -76,6 +77,7 @@ static struct debug_mux disp0_cc = {
+ static struct debug_mux disp1_cc = {
+ 	.phys = 0x22100000,
+ 	.size = 0x20000,
++	.block_name = "disp1",
+ 
+ 	.enable_reg = 0x500c,
+ 	.enable_mask = BIT(0),
+diff --git a/sdm845.c b/sdm845.c
+index 8abade19cfdd..a66abf90346d 100644
+--- a/sdm845.c
++++ b/sdm845.c
+@@ -71,6 +71,7 @@ static struct debug_mux gcc = {
+ static struct debug_mux cam_cc = {
+ 	.phys = 0xad00000,
+ 	.size = 0x10000,
++	.block_name = "cam",
+ 
+ 	.enable_reg = 0xc008,
+ 	.enable_mask = BIT(0),
+@@ -85,6 +86,7 @@ static struct debug_mux cam_cc = {
+ static struct debug_mux cpu = {
+ 	.phys = 0x17970000,
+ 	.size = 4096,
++	.block_name = "cpu",
+ 
+ 	.enable_reg = 0x18,
+ 	.enable_mask = BIT(0),
+@@ -101,6 +103,7 @@ static struct debug_mux cpu = {
+ static struct debug_mux disp_cc = {
+ 	.phys = 0xaf00000,
+ 	.size = 0x10000,
++	.block_name = "disp",
+ 
+ 	.enable_reg = 0x600c,
+ 	.enable_mask = BIT(0),
+@@ -115,6 +118,7 @@ static struct debug_mux disp_cc = {
+ static struct debug_mux gpu_cc = {
+ 	.phys = 0x5090000,
+ 	.size = 0x9000,
++	.block_name = "gpu",
+ 
+ 	.enable_reg = 0x1100,
+ 	.enable_mask = BIT(0),
+@@ -129,6 +133,7 @@ static struct debug_mux gpu_cc = {
+ static struct debug_mux video_cc = {
+ 	.phys = 0xab00000,
+ 	.size = 0x10000,
++	.block_name = "video",
+ 
+ 	.enable_reg = 0xa58,
+ 	.enable_mask = BIT(0),
+diff --git a/sm8350.c b/sm8350.c
+index 58a41654c0b2..ecf8ea94afeb 100644
+--- a/sm8350.c
++++ b/sm8350.c
+@@ -71,6 +71,7 @@ static struct debug_mux gcc = {
+ static struct debug_mux cam_cc = {
+ 	.phys = 0xad00000,
+ 	.size = 0x10000,
++	.block_name = "cam",
+ 
+ 	.enable_reg = 0xd008,
+ 	.enable_mask = BIT(0),
+@@ -86,6 +87,7 @@ static struct debug_mux cam_cc = {
+ static struct debug_mux disp_cc = {
+ 	.phys = 0xaf00000,
+ 	.size = 0x10000,
++	.block_name = "disp",
+ 
+ 	.enable_reg = 0x500c,
+ 	.enable_mask = BIT(0),
+@@ -101,6 +103,7 @@ static struct debug_mux disp_cc = {
+ static struct debug_mux gpu_cc = {
+ 	.phys = 0x3d90000,
+ 	.size = 0x9000,
++	.block_name = "gpu",
+ 
+ 	.enable_reg = 0x1100,
+ 	.enable_mask = BIT(0),
+@@ -116,6 +119,7 @@ static struct debug_mux gpu_cc = {
+ static struct debug_mux video_cc = {
+ 	.phys = 0xaaf0000,
+ 	.size = 0x10000,
++	.block_name = "video",
+ 
+ 	.enable_reg = 0xebc,
+ 	.enable_mask = BIT(0),
+diff --git a/sm8450.c b/sm8450.c
+index ba1c9857ec24..a04de128ae4d 100644
+--- a/sm8450.c
++++ b/sm8450.c
+@@ -82,6 +82,7 @@ static struct debug_mux apss_cc = {
+ static struct debug_mux cam_cc = {
+ 	.phys = 0xade0000,
+ 	.size = 0x20000,
++	.block_name = "cam",
+ 
+ 	.enable_reg = 0x14008,
+ 	.enable_mask = BIT(0),
+@@ -97,6 +98,7 @@ static struct debug_mux cam_cc = {
+ static struct debug_mux disp_cc = {
+ 	.phys = 0xaf00000,
+ 	.size = 0x20000,
++	.block_name = "disp",
+ 
+ 	.enable_reg = 0xd00c,
+ 	.enable_mask = BIT(0),
+@@ -112,6 +114,7 @@ static struct debug_mux disp_cc = {
+ static struct debug_mux gpu_cc = {
+ 	.phys = 0x3d90000,
+ 	.size = 0xa000,
++	.block_name = "gpu",
+ 
+ 	.enable_reg = 0x9274,
+ 	.enable_mask = BIT(0),
+@@ -127,6 +130,7 @@ static struct debug_mux gpu_cc = {
+ static struct debug_mux video_cc = {
+ 	.phys = 0xaaf0000,
+ 	.size = 0x10000,
++	.block_name = "video",
+ 
+ 	.enable_reg = 0x80ec,
+ 	.enable_mask = BIT(0),
+-- 
+2.35.1
+

--- a/recipes-devtools/debugcc/debugcc/msm8996/0001-debugcc-preserve-xo_div4-contents.patch
+++ b/recipes-devtools/debugcc/debugcc/msm8996/0001-debugcc-preserve-xo_div4-contents.patch
@@ -1,0 +1,45 @@
+From b41b1451173a202d1edbf51bfd9267526140a5b3 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Wed, 21 Sep 2022 23:02:19 +0300
+Subject: [PATCH 1/4] debugcc: preserve xo_div4 contents
+
+Preserve the contents of the xo_div4 register. Downstream kernel
+preserves the contents of the register. Writing just 1 makes the msm8996
+report the value divided by 4 rather than the actual clock frequency.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+---
+ debugcc.c | 6 ++++--
+ 1 file changed, 4 insertions(+), 2 deletions(-)
+
+diff --git a/debugcc.c b/debugcc.c
+index 04e7956e0f5c..041ab8a10491 100644
+--- a/debugcc.c
++++ b/debugcc.c
+@@ -133,6 +133,7 @@ static void measure(const struct measure_clk *clk)
+ 	unsigned long raw_count_short;
+ 	unsigned long raw_count_full;
+ 	struct debug_mux *gcc = clk->primary;
++	unsigned long xo_div4;
+ 
+ 	if (!leaf_enabled(gcc, clk->leaf)) {
+ 		printf("%50s: skipping\n", clk->name);
+@@ -144,12 +145,13 @@ static void measure(const struct measure_clk *clk)
+ 
+ 	mux_enable(clk->primary, clk->mux);
+ 
+-	writel(1, gcc->base + gcc->xo_div4_reg);
++	xo_div4 = readl(gcc->base + gcc->xo_div4_reg);
++	writel(xo_div4 | 1, gcc->base + gcc->xo_div4_reg);
+ 
+ 	raw_count_short = measure_ticks(gcc, 0x1000);
+ 	raw_count_full = measure_ticks(gcc, 0x10000);
+ 
+-	writel(0, gcc->base + gcc->xo_div4_reg);
++	writel(xo_div4, gcc->base + gcc->xo_div4_reg);
+ 
+ 	if (raw_count_full == raw_count_short) {
+ 		printf("%50s: off\n", clk->name);
+-- 
+2.35.1
+

--- a/recipes-devtools/debugcc/debugcc/msm8996/0002-msm8996-add-support-for-MSM8996-platform.patch
+++ b/recipes-devtools/debugcc/debugcc/msm8996/0002-msm8996-add-support-for-MSM8996-platform.patch
@@ -1,0 +1,390 @@
+From e3253448e793aefa01397aab3392e0fcc7b79a86 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Thu, 22 Sep 2022 00:30:02 +0300
+Subject: [PATCH 2/4] msm8996: add support for MSM8996 platform
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+---
+ Makefile  |   3 +-
+ debugcc.c |   1 +
+ debugcc.h |   1 +
+ msm8996.c | 324 ++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 328 insertions(+), 1 deletion(-)
+ create mode 100644 msm8996.c
+
+diff --git a/Makefile b/Makefile
+index a59bb3158103..debaa12df764 100644
+--- a/Makefile
++++ b/Makefile
+@@ -6,12 +6,13 @@ CFLAGS := -O2 -Wall -g
+ LDFLAGS := -static -static-libgcc
+ prefix := /usr/local
+ 
+-SRCS := debugcc.c msm8936.c qcs404.c sc8280xp.c sdm845.c sm8350.c sm8450.c
++SRCS := debugcc.c msm8936.c msm8996.c qcs404.c sc8280xp.c sdm845.c sm8350.c sm8450.c
+ OBJS := $(SRCS:.c=.o)
+ 
+ $(OUT): $(OBJS)
+ 	$(CC) -o $@ $^ $(LDFLAGS)
+ 	ln -f $(OUT) msm8936-debugcc
++	ln -f $(OUT) msm8996-debugcc
+ 	ln -f $(OUT) qcs404-debugcc
+ 	ln -f $(OUT) sc8280xp-debugcc
+ 	ln -f $(OUT) sdm845-debugcc
+diff --git a/debugcc.c b/debugcc.c
+index 041ab8a10491..b609d0c75f5e 100644
+--- a/debugcc.c
++++ b/debugcc.c
+@@ -44,6 +44,7 @@
+ 
+ static const struct debugcc_platform *platforms[] = {
+ 	&msm8936_debugcc,
++	&msm8996_debugcc,
+ 	&qcs404_debugcc,
+ 	&sc8280xp_debugcc,
+ 	&sdm845_debugcc,
+diff --git a/debugcc.h b/debugcc.h
+index 5a51efdc2535..3bcf80f70397 100644
+--- a/debugcc.h
++++ b/debugcc.h
+@@ -75,6 +75,7 @@ struct debugcc_platform {
+ };
+ 
+ extern struct debugcc_platform msm8936_debugcc;
++extern struct debugcc_platform msm8996_debugcc;
+ extern struct debugcc_platform qcs404_debugcc;
+ extern struct debugcc_platform sc8280xp_debugcc;
+ extern struct debugcc_platform sdm845_debugcc;
+diff --git a/msm8996.c b/msm8996.c
+new file mode 100644
+index 000000000000..eed8843dd77a
+--- /dev/null
++++ b/msm8996.c
+@@ -0,0 +1,324 @@
++/*
++ * Copyright (c) 2022, Linaro Ltd.
++ * All rights reserved.
++ *
++ * Redistribution and use in source and binary forms, with or without
++ * modification, are permitted provided that the following conditions are met:
++ *
++ * 1. Redistributions of source code must retain the above copyright notice,
++ * this list of conditions and the following disclaimer.
++ *
++ * 2. Redistributions in binary form must reproduce the above copyright notice,
++ * this list of conditions and the following disclaimer in the documentation
++ * and/or other materials provided with the distribution.
++ *
++ * 3. Neither the name of the copyright holder nor the names of its contributors
++ * may be used to endorse or promote products derived from this software without
++ * specific prior written permission.
++ *
++ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
++ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
++ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
++ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
++ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
++ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
++ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
++ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
++ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
++ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
++ * POSSIBILITY OF SUCH DAMAGE.
++ */
++#include <sys/mman.h>
++#include <err.h>
++#include <errno.h>
++#include <fcntl.h>
++#include <stdbool.h>
++#include <stdio.h>
++#include <stdint.h>
++#include <stdlib.h>
++#include <string.h>
++#include <unistd.h>
++
++#include "debugcc.h"
++
++#define GCC_BASE			0x300000
++#define GCC_SIZE			0x8f014
++
++#define GCC_DEBUG_CLK_CTL		0x62000
++#define GCC_DEBUG_CTL			0x62004
++#define GCC_DEBUG_STATUS		0x62008
++#define GCC_XO_DIV4_CBCR		0x43008
++
++static struct debug_mux gcc = {
++	.phys =	GCC_BASE,
++	.size = GCC_SIZE,
++
++	.enable_reg = GCC_DEBUG_CLK_CTL,
++	.enable_mask = BIT(16),
++
++	.mux_reg = GCC_DEBUG_CLK_CTL,
++	.mux_mask = 0x3ff,
++
++	.div_reg = GCC_DEBUG_CLK_CTL,
++	.div_shift = 12,
++	.div_mask = 0xf << 12,
++	.div_val = 1,
++
++	.xo_div4_reg = GCC_XO_DIV4_CBCR,
++	.debug_ctl_reg = GCC_DEBUG_CTL,
++	.debug_status_reg = GCC_DEBUG_STATUS,
++};
++
++static struct debug_mux mmss_cc = {
++	.phys = 0x8c0000,
++	.size = 0xb00c,
++
++	.enable_reg = 0x900,
++	.enable_mask = BIT(16),
++
++	.mux_reg = 0x900,
++	.mux_mask = 0x3ff,
++};
++
++static struct measure_clk msm8996_clocks[] = {
++	{ "snoc_clk", &gcc, 0x0000 },
++	{ "gcc_sys_noc_usb3_axi_clk", &gcc, 0x0006 },
++	{ "gcc_sys_noc_ufs_axi_clk", &gcc, 0x0007 },
++	{ "cnoc_clk", &gcc, 0x000e },
++	{ "pnoc_clk", &gcc, 0x0011 },
++	{ "gcc_periph_noc_usb20_ahb_clk", &gcc, 0x0014 },
++	{ "gcc_mmss_noc_cfg_ahb_clk", &gcc, 0x0019 },
++	//{ "mmss_gcc_dbg_clk", &gcc, 0x001b },
++	{ "mmss_mmagic_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0001 },
++	{ "mmss_misc_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0003 },
++	{ "vmem_maxi_clk", &gcc, 0x1b, &mmss_cc, 0x0009 },
++	{ "vmem_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x000a },
++	{ "gpu_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x000c },
++	{ "gpu_gx_gfx3d_clk", &gcc, 0x1b, &mmss_cc, 0x000d },
++	{ "video_core_clk", &gcc, 0x1b, &mmss_cc, 0x000e },
++	{ "video_axi_clk", &gcc, 0x1b, &mmss_cc, 0x000f },
++	{ "video_maxi_clk", &gcc, 0x1b, &mmss_cc, 0x0010 },
++	{ "video_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0011 },
++	{ "mmss_rbcpr_clk", &gcc, 0x1b, &mmss_cc, 0x0012 },
++	{ "mmss_rbcpr_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0013 },
++	{ "mdss_mdp_clk", &gcc, 0x1b, &mmss_cc, 0x0014 },
++	{ "mdss_pclk0_clk", &gcc, 0x1b, &mmss_cc, 0x0016 },
++	{ "mdss_pclk1_clk", &gcc, 0x1b, &mmss_cc, 0x0017 },
++	{ "mdss_extpclk_clk", &gcc, 0x1b, &mmss_cc, 0x0018 },
++	{ "video_subcore0_clk", &gcc, 0x1b, &mmss_cc, 0x001a },
++	{ "video_subcore1_clk", &gcc, 0x1b, &mmss_cc, 0x001b },
++	{ "mdss_vsync_clk", &gcc, 0x1b, &mmss_cc, 0x001c },
++	{ "mdss_hdmi_clk", &gcc, 0x1b, &mmss_cc, 0x001d },
++	{ "mdss_byte0_clk", &gcc, 0x1b, &mmss_cc, 0x001e },
++	{ "mdss_byte1_clk", &gcc, 0x1b, &mmss_cc, 0x001f },
++	{ "mdss_esc0_clk", &gcc, 0x1b, &mmss_cc, 0x0020 },
++	{ "mdss_esc1_clk", &gcc, 0x1b, &mmss_cc, 0x0021 },
++	{ "mdss_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0022 },
++	{ "mdss_hdmi_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0023 },
++	{ "mdss_axi_clk", &gcc, 0x1b, &mmss_cc, 0x0024 },
++	{ "camss_top_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0025 },
++	{ "camss_micro_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0026 },
++	{ "camss_gp0_clk", &gcc, 0x1b, &mmss_cc, 0x0027 },
++	{ "camss_gp1_clk", &gcc, 0x1b, &mmss_cc, 0x0028 },
++	{ "camss_mclk0_clk", &gcc, 0x1b, &mmss_cc, 0x0029 },
++	{ "camss_mclk1_clk", &gcc, 0x1b, &mmss_cc, 0x002a },
++	{ "camss_mclk2_clk", &gcc, 0x1b, &mmss_cc, 0x002b },
++	{ "camss_mclk3_clk", &gcc, 0x1b, &mmss_cc, 0x002c },
++	{ "camss_cci_clk", &gcc, 0x1b, &mmss_cc, 0x002d },
++	{ "camss_cci_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x002e },
++	{ "camss_csi0phytimer_clk", &gcc, 0x1b, &mmss_cc, 0x002f },
++	{ "camss_csi1phytimer_clk", &gcc, 0x1b, &mmss_cc, 0x0030 },
++	{ "camss_csi2phytimer_clk", &gcc, 0x1b, &mmss_cc, 0x0031 },
++	{ "camss_jpeg0_clk", &gcc, 0x1b, &mmss_cc, 0x0032 },
++	{ "camss_ispif_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0033 },
++	{ "camss_jpeg2_clk", &gcc, 0x1b, &mmss_cc, 0x0034 },
++	{ "camss_jpeg_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0035 },
++	{ "camss_jpeg_axi_clk", &gcc, 0x1b, &mmss_cc, 0x0036 },
++	{ "camss_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0037 },
++	{ "camss_vfe0_clk", &gcc, 0x1b, &mmss_cc, 0x0038 },
++	{ "camss_vfe1_clk", &gcc, 0x1b, &mmss_cc, 0x0039 },
++	{ "camss_cpp_clk", &gcc, 0x1b, &mmss_cc, 0x003a },
++	{ "camss_cpp_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x003b },
++	{ "camss_vfe_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x003c },
++	{ "camss_vfe_axi_clk", &gcc, 0x1b, &mmss_cc, 0x003d },
++	{ "gpu_gx_rbbmtimer_clk", &gcc, 0x1b, &mmss_cc, 0x003e },
++	{ "camss_csi_vfe0_clk", &gcc, 0x1b, &mmss_cc, 0x003f },
++	{ "camss_csi_vfe1_clk", &gcc, 0x1b, &mmss_cc, 0x0040 },
++	{ "camss_csi0_clk", &gcc, 0x1b, &mmss_cc, 0x0041 },
++	{ "camss_csi0_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0042 },
++	{ "camss_csi0phy_clk", &gcc, 0x1b, &mmss_cc, 0x0043 },
++	{ "camss_csi0rdi_clk", &gcc, 0x1b, &mmss_cc, 0x0044 },
++	{ "camss_csi0pix_clk", &gcc, 0x1b, &mmss_cc, 0x0045 },
++	{ "camss_csi1_clk", &gcc, 0x1b, &mmss_cc, 0x0046 },
++	{ "camss_csi1_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0047 },
++	{ "camss_csi1phy_clk", &gcc, 0x1b, &mmss_cc, 0x0048 },
++	{ "camss_csi1rdi_clk", &gcc, 0x1b, &mmss_cc, 0x0049 },
++	{ "camss_csi1pix_clk", &gcc, 0x1b, &mmss_cc, 0x004a },
++	{ "camss_csi2_clk", &gcc, 0x1b, &mmss_cc, 0x004b },
++	{ "camss_csi2_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x004c },
++	{ "camss_csi2phy_clk", &gcc, 0x1b, &mmss_cc, 0x004d },
++	{ "camss_csi2rdi_clk", &gcc, 0x1b, &mmss_cc, 0x004e },
++	{ "camss_csi2pix_clk", &gcc, 0x1b, &mmss_cc, 0x004f },
++	{ "camss_csi3_clk", &gcc, 0x1b, &mmss_cc, 0x0050 },
++	{ "camss_csi3_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0051 },
++	{ "camss_csi3phy_clk", &gcc, 0x1b, &mmss_cc, 0x0052 },
++	{ "camss_csi3rdi_clk", &gcc, 0x1b, &mmss_cc, 0x0053 },
++	{ "camss_csi3pix_clk", &gcc, 0x1b, &mmss_cc, 0x0054 },
++	{ "mmss_mmagic_maxi_clk", &gcc, 0x1b, &mmss_cc, 0x0070 },
++	{ "camss_vfe0_stream_clk", &gcc, 0x1b, &mmss_cc, 0x0071 },
++	{ "camss_vfe1_stream_clk", &gcc, 0x1b, &mmss_cc, 0x0072 },
++	{ "camss_cpp_vbif_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0073 },
++	{ "mmss_mmagic_cfg_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0074 },
++	{ "mmss_misc_cxo_clk", &gcc, 0x1b, &mmss_cc, 0x0077 },
++	{ "camss_cpp_axi_clk", &gcc, 0x1b, &mmss_cc, 0x007a },
++	{ "camss_jpeg_dma_clk", &gcc, 0x1b, &mmss_cc, 0x007b },
++	{ "camss_vfe0_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0086 },
++	{ "camss_vfe1_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0087 },
++	{ "gpu_aon_isense_clk", &gcc, 0x1b, &mmss_cc, 0x0088 },
++	{ "fd_core_clk", &gcc, 0x1b, &mmss_cc, 0x0089 },
++	{ "fd_core_uar_clk", &gcc, 0x1b, &mmss_cc, 0x008a },
++	{ "fd_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x008c },
++	{ "camss_csiphy0_3p_clk", &gcc, 0x1b, &mmss_cc, 0x0091 },
++	{ "camss_csiphy1_3p_clk", &gcc, 0x1b, &mmss_cc, 0x0092 },
++	{ "camss_csiphy2_3p_clk", &gcc, 0x1b, &mmss_cc, 0x0093 },
++	{ "smmu_vfe_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0094 },
++	{ "smmu_vfe_axi_clk", &gcc, 0x1b, &mmss_cc, 0x0095 },
++	{ "smmu_cpp_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0096 },
++	{ "smmu_cpp_axi_clk", &gcc, 0x1b, &mmss_cc, 0x0097 },
++	{ "smmu_jpeg_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x0098 },
++	{ "smmu_jpeg_axi_clk", &gcc, 0x1b, &mmss_cc, 0x0099 },
++	{ "mmagic_camss_axi_clk", &gcc, 0x1b, &mmss_cc, 0x009a },
++	{ "smmu_rot_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x009b },
++	{ "smmu_rot_axi_clk", &gcc, 0x1b, &mmss_cc, 0x009c },
++	{ "smmu_mdp_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x009d },
++	{ "smmu_mdp_axi_clk", &gcc, 0x1b, &mmss_cc, 0x009e },
++	{ "mmagic_mdss_axi_clk", &gcc, 0x1b, &mmss_cc, 0x009f },
++	{ "smmu_video_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x00a0 },
++	{ "smmu_video_axi_clk", &gcc, 0x1b, &mmss_cc, 0x00a1 },
++	{ "mmagic_video_axi_clk", &gcc, 0x1b, &mmss_cc, 0x00a2 },
++	{ "mmagic_camss_noc_cfg_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x00ad },
++	{ "mmagic_mdss_noc_cfg_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x00ae },
++	{ "mmagic_video_noc_cfg_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x00af },
++	{ "mmagic_bimc_noc_cfg_ahb_clk", &gcc, 0x1b, &mmss_cc, 0x00b0 },
++	{ "gcc_mmss_bimc_gfx_clk", &gcc, 0x001c},
++	{ "gcc_usb30_master_clk", &gcc, 0x002d },
++	{ "gcc_usb30_sleep_clk", &gcc, 0x002e },
++	{ "gcc_usb30_mock_utmi_clk", &gcc, 0x002f },
++	{ "gcc_usb3_phy_aux_clk", &gcc, 0x0030 },
++	{ "gcc_usb3_phy_pipe_clk", &gcc, 0x0031 },
++	{ "gcc_usb20_master_clk", &gcc, 0x0035 },
++	{ "gcc_usb20_sleep_clk", &gcc, 0x0036 },
++	{ "gcc_usb20_mock_utmi_clk", &gcc, 0x0037 },
++	{ "gcc_usb_phy_cfg_ahb2phy_clk", &gcc, 0x0038 },
++	{ "gcc_sdcc1_apps_clk", &gcc, 0x0039 },
++	{ "gcc_sdcc1_ahb_clk", &gcc, 0x003a },
++	{ "gcc_sdcc2_apps_clk", &gcc, 0x003b },
++	{ "gcc_sdcc2_ahb_clk", &gcc, 0x003c },
++	{ "gcc_sdcc3_apps_clk", &gcc, 0x003d },
++	{ "gcc_sdcc3_ahb_clk", &gcc, 0x003e },
++	{ "gcc_sdcc4_apps_clk", &gcc, 0x003f },
++	{ "gcc_sdcc4_ahb_clk", &gcc, 0x0040 },
++	{ "gcc_blsp1_ahb_clk", &gcc, 0x0041 },
++	{ "gcc_blsp1_qup1_spi_apps_clk", &gcc, 0x0043 },
++	{ "gcc_blsp1_qup1_i2c_apps_clk", &gcc, 0x0044 },
++	{ "gcc_blsp1_uart1_apps_clk", &gcc, 0x0045 },
++	{ "gcc_blsp1_qup2_spi_apps_clk", &gcc, 0x0047 },
++	{ "gcc_blsp1_qup2_i2c_apps_clk", &gcc, 0x0048 },
++	{ "gcc_blsp1_uart2_apps_clk", &gcc, 0x0049 },
++	{ "gcc_blsp1_qup3_spi_apps_clk", &gcc, 0x004b },
++	{ "gcc_blsp1_qup3_i2c_apps_clk", &gcc, 0x004c },
++	{ "gcc_blsp1_uart3_apps_clk", &gcc, 0x004d },
++	{ "gcc_blsp1_qup4_spi_apps_clk", &gcc, 0x004f },
++	{ "gcc_blsp1_qup4_i2c_apps_clk", &gcc, 0x0050 },
++	{ "gcc_blsp1_uart4_apps_clk", &gcc, 0x0051 },
++	{ "gcc_blsp1_qup5_spi_apps_clk", &gcc, 0x0053 },
++	{ "gcc_blsp1_qup5_i2c_apps_clk", &gcc, 0x0054 },
++	{ "gcc_blsp1_uart5_apps_clk", &gcc, 0x0055 },
++	{ "gcc_blsp1_qup6_spi_apps_clk", &gcc, 0x0057 },
++	{ "gcc_blsp1_qup6_i2c_apps_clk", &gcc, 0x0058 },
++	{ "gcc_blsp1_uart6_apps_clk", &gcc, 0x0059 },
++	{ "gcc_blsp2_ahb_clk", &gcc, 0x005b },
++	{ "gcc_blsp2_qup1_spi_apps_clk", &gcc, 0x005d },
++	{ "gcc_blsp2_qup1_i2c_apps_clk", &gcc, 0x005e },
++	{ "gcc_blsp2_uart1_apps_clk", &gcc, 0x005f },
++	{ "gcc_blsp2_qup2_spi_apps_clk", &gcc, 0x0061 },
++	{ "gcc_blsp2_qup2_i2c_apps_clk", &gcc, 0x0062 },
++	{ "gcc_blsp2_uart2_apps_clk", &gcc, 0x0063 },
++	{ "gcc_blsp2_qup3_spi_apps_clk", &gcc, 0x0065 },
++	{ "gcc_blsp2_qup3_i2c_apps_clk", &gcc, 0x0066 },
++	{ "gcc_blsp2_uart3_apps_clk", &gcc, 0x0067 },
++	{ "gcc_blsp2_qup4_spi_apps_clk", &gcc, 0x0069 },
++	{ "gcc_blsp2_qup4_i2c_apps_clk", &gcc, 0x006a },
++	{ "gcc_blsp2_uart4_apps_clk", &gcc, 0x006b },
++	{ "gcc_blsp2_qup5_spi_apps_clk", &gcc, 0x006d },
++	{ "gcc_blsp2_qup5_i2c_apps_clk", &gcc, 0x006e },
++	{ "gcc_blsp2_uart5_apps_clk", &gcc, 0x006f },
++	{ "gcc_blsp2_qup6_spi_apps_clk", &gcc, 0x0071 },
++	{ "gcc_blsp2_qup6_i2c_apps_clk", &gcc, 0x0072 },
++	{ "gcc_blsp2_uart6_apps_clk", &gcc, 0x0073 },
++	{ "gcc_pdm_ahb_clk", &gcc, 0x0076 },
++	{ "gcc_pdm2_clk", &gcc, 0x0078 },
++	{ "gcc_prng_ahb_clk", &gcc, 0x0079 },
++	{ "gcc_tsif_ahb_clk", &gcc, 0x007a },
++	{ "gcc_tsif_ref_clk", &gcc, 0x007b },
++	{ "gcc_boot_rom_ahb_clk", &gcc, 0x007e },
++	{ "ce1_clk", &gcc, 0x0099 },
++	{ "gcc_ce1_axi_m_clk", &gcc, 0x009a },
++	{ "gcc_ce1_ahb_m_clk", &gcc, 0x009b },
++	{ "measure_only_bimc_hmss_axi_clk", &gcc, 0x00a5 },
++	{ "bimc_clk", &gcc, 0x00ad },
++	{ "gcc_bimc_gfx_clk", &gcc, 0x00af},
++	{ "gcc_hmss_rbcpr_clk", &gcc, 0x00ba },
++	//{ "cpu_dbg_clk", &gcc, 0x00bb },
++	{ "gcc_gp1_clk", &gcc, 0x00e3 },
++	{ "gcc_gp2_clk", &gcc, 0x00e4 },
++	{ "gcc_gp3_clk", &gcc, 0x00e5 },
++	{ "gcc_pcie_0_slv_axi_clk", &gcc, 0x00e6 },
++	{ "gcc_pcie_0_mstr_axi_clk", &gcc, 0x00e7 },
++	{ "gcc_pcie_0_cfg_ahb_clk", &gcc, 0x00e8 },
++	{ "gcc_pcie_0_aux_clk", &gcc, 0x00e9 },
++	{ "gcc_pcie_0_pipe_clk", &gcc, 0x00ea },
++	{ "gcc_pcie_1_slv_axi_clk", &gcc, 0x00ec },
++	{ "gcc_pcie_1_mstr_axi_clk", &gcc, 0x00ed },
++	{ "gcc_pcie_1_cfg_ahb_clk", &gcc, 0x00ee },
++	{ "gcc_pcie_1_aux_clk", &gcc, 0x00ef },
++	{ "gcc_pcie_1_pipe_clk", &gcc, 0x00f0 },
++	{ "gcc_pcie_2_slv_axi_clk", &gcc, 0x00f2 },
++	{ "gcc_pcie_2_mstr_axi_clk", &gcc, 0x00f3 },
++	{ "gcc_pcie_2_cfg_ahb_clk", &gcc, 0x00f4 },
++	{ "gcc_pcie_2_aux_clk", &gcc, 0x00f5 },
++	{ "gcc_pcie_2_pipe_clk", &gcc, 0x00f6 },
++	{ "gcc_pcie_phy_cfg_ahb_clk", &gcc, 0x00f8 },
++	{ "gcc_pcie_phy_aux_clk", &gcc, 0x00f9 },
++	{ "gcc_ufs_axi_clk", &gcc, 0x00fc },
++	{ "gcc_ufs_ahb_clk", &gcc, 0x00fd },
++	{ "gcc_ufs_tx_cfg_clk", &gcc, 0x00fe },
++	{ "gcc_ufs_rx_cfg_clk", &gcc, 0x00ff },
++	{ "gcc_ufs_tx_symbol_0_clk", &gcc, 0x0100 },
++	{ "gcc_ufs_rx_symbol_0_clk", &gcc, 0x0101 },
++	{ "gcc_ufs_rx_symbol_1_clk", &gcc, 0x0102 },
++	{ "gcc_ufs_unipro_core_clk", &gcc, 0x0106 },
++	{ "gcc_ufs_ice_core_clk", &gcc, 0x0107 },
++	{ "gcc_ufs_sys_clk_core_clk", &gcc, 0x108},
++	{ "gcc_ufs_tx_symbol_clk_core_clk", &gcc, 0x0109 },
++	{ "gcc_aggre0_snoc_axi_clk", &gcc, 0x0116 },
++	{ "gcc_aggre0_cnoc_ahb_clk", &gcc, 0x0117 },
++	{ "gcc_smmu_aggre0_axi_clk", &gcc, 0x0119 },
++	{ "gcc_smmu_aggre0_ahb_clk", &gcc, 0x011a },
++	{ "gcc_aggre0_noc_qosgen_extref_clk", &gcc, 0x011b },
++	{ "gcc_aggre2_ufs_axi_clk", &gcc, 0x0126 },
++	{ "gcc_aggre2_usb3_axi_clk", &gcc, 0x0127 },
++	{ "gcc_dcc_ahb_clk", &gcc, 0x012b },
++	{ "gcc_aggre0_noc_mpu_cfg_ahb_clk", &gcc, 0x012c},
++	{ "ipa_clk", &gcc, 0x12f },
++	{ "gcc_mss_cfg_ahb_clk", &gcc, 0x0133 },
++	{ "gcc_mss_mnoc_bimc_axi_clk", &gcc, 0x0134 },
++	{ "gcc_mss_snoc_axi_clk", &gcc, 0x0135 },
++	{ "gcc_mss_q6_bimc_axi_clk", &gcc, 0x0136 },
++	{}
++};
++
++struct debugcc_platform msm8996_debugcc = {
++	"msm8996",
++	msm8996_clocks,
++};
+-- 
+2.35.1
+

--- a/recipes-devtools/debugcc/debugcc/msm8996/0003-debugcc-allow-customizing-the-measurement-process.patch
+++ b/recipes-devtools/debugcc/debugcc/msm8996/0003-debugcc-allow-customizing-the-measurement-process.patch
@@ -1,0 +1,122 @@
+From 5522765415b6a2e4033981ad71c0298a7bc28fd0 Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Fri, 23 Sep 2022 17:57:15 +0300
+Subject: [PATCH 3/4] debugcc: allow customizing the measurement process
+
+MSM8996 requires additional setup to measure CPU clocks. Add hooks to
+customize the mux enable/disable and measurement process.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+---
+ debugcc.c | 29 ++++++++++++++++++++++++-----
+ debugcc.h |  8 ++++++++
+ 2 files changed, 32 insertions(+), 5 deletions(-)
+
+diff --git a/debugcc.c b/debugcc.c
+index b609d0c75f5e..e19462fcf13f 100644
+--- a/debugcc.c
++++ b/debugcc.c
+@@ -84,7 +84,7 @@ static unsigned int measure_ticks(struct debug_mux *gcc, unsigned int ticks)
+ 	return val;
+ }
+ 
+-static void mux_enable(struct debug_mux *mux, int selector)
++static void mux_prepare_enable(struct debug_mux *mux, int selector)
+ {
+ 	uint32_t val;
+ 
+@@ -100,15 +100,28 @@ static void mux_enable(struct debug_mux *mux, int selector)
+ 		writel(val, mux->base + mux->div_reg);
+ 	}
+ 
++	mux_enable(mux);
++}
++
++void mux_enable(struct debug_mux *mux)
++{
++	uint32_t val;
++
+ 	val = readl(mux->base + mux->enable_reg);
+ 	val |= mux->enable_mask;
+ 	writel(val, mux->base + mux->enable_reg);
++
++	if (mux->premeasure)
++		mux->premeasure(mux);
+ }
+ 
+-static void mux_disable(struct debug_mux *mux)
++void mux_disable(struct debug_mux *mux)
+ {
+ 	uint32_t val;
+ 
++	if (mux->postmeasure)
++		mux->postmeasure(mux);
++
+ 	val = readl(mux->base + mux->enable_reg);
+ 	val &= ~mux->enable_mask;
+ 	writel(val, mux->base + mux->enable_reg);
+@@ -142,9 +155,9 @@ static void measure(const struct measure_clk *clk)
+ 	}
+ 
+ 	if (clk->leaf)
+-		mux_enable(clk->leaf, clk->leaf_mux);
++		mux_prepare_enable(clk->leaf, clk->leaf_mux);
+ 
+-	mux_enable(clk->primary, clk->mux);
++	mux_prepare_enable(clk->primary, clk->mux);
+ 
+ 	xo_div4 = readl(gcc->base + gcc->xo_div4_reg);
+ 	writel(xo_div4 | 1, gcc->base + gcc->xo_div4_reg);
+@@ -238,7 +251,7 @@ static void list_clocks(const struct debugcc_platform *platform)
+ 		printf("%s\n", clk->name);
+ }
+ 
+-static int mmap_mux(int devmem, struct debug_mux *mux)
++int mmap_mux(int devmem, struct debug_mux *mux)
+ {
+ 	/* Do nothing if this mux has already been mapped */
+ 	if (!mux || mux->base)
+@@ -346,6 +359,12 @@ int main(int argc, char **argv)
+ 	if (devmem < 0)
+ 		err(1, "failed to open /dev/mem");
+ 
++	if (platform->premap) {
++		ret = platform->premap(devmem);
++		if (ret < 0)
++			exit (1);
++	}
++
+ 	ret = mmap_hardware(devmem, platform);
+ 	if (ret < 0)
+ 		exit(1);
+diff --git a/debugcc.h b/debugcc.h
+index 3bcf80f70397..ffadfb642da7 100644
+--- a/debugcc.h
++++ b/debugcc.h
+@@ -56,6 +56,9 @@ struct debug_mux {
+ 
+ 	unsigned int ahb_reg;
+ 	unsigned int ahb_mask;
++
++	void (*premeasure)(struct debug_mux *mux);
++	void (*postmeasure)(struct debug_mux *mux);
+ };
+ 
+ struct measure_clk {
+@@ -72,8 +75,13 @@ struct measure_clk {
+ struct debugcc_platform {
+ 	const char *name;
+ 	const struct measure_clk *clocks;
++	int (*premap)(int devmem);
+ };
+ 
++int mmap_mux(int devmem, struct debug_mux *mux);
++void mux_enable(struct debug_mux *mux);
++void mux_disable(struct debug_mux *mux);
++
+ extern struct debugcc_platform msm8936_debugcc;
+ extern struct debugcc_platform msm8996_debugcc;
+ extern struct debugcc_platform qcs404_debugcc;
+-- 
+2.35.1
+

--- a/recipes-devtools/debugcc/debugcc/msm8996/0003-debugcc-allow-customizing-the-measurement-process.patch
+++ b/recipes-devtools/debugcc/debugcc/msm8996/0003-debugcc-allow-customizing-the-measurement-process.patch
@@ -68,7 +68,7 @@ index b609d0c75f5e..e19462fcf13f 100644
  	xo_div4 = readl(gcc->base + gcc->xo_div4_reg);
  	writel(xo_div4 | 1, gcc->base + gcc->xo_div4_reg);
 @@ -238,7 +251,7 @@ static void list_clocks(const struct debugcc_platform *platform)
- 		printf("%s\n", clk->name);
+ 	}
  }
  
 -static int mmap_mux(int devmem, struct debug_mux *mux)

--- a/recipes-devtools/debugcc/debugcc/msm8996/0004-msm8996-add-support-for-CPU-clocks.patch
+++ b/recipes-devtools/debugcc/debugcc/msm8996/0004-msm8996-add-support-for-CPU-clocks.patch
@@ -1,0 +1,97 @@
+From cb7677dc3d8881c35f70742db9c22f708a54f45c Mon Sep 17 00:00:00 2001
+From: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+Date: Fri, 23 Sep 2022 18:00:32 +0300
+Subject: [PATCH 4/4] msm8996: add support for CPU clocks
+
+Measure CPU clusters and CBF clocks.
+
+Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>
+---
+ msm8996.c | 56 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+ 1 file changed, 56 insertions(+)
+
+diff --git a/msm8996.c b/msm8996.c
+index eed8843dd77a..bde2a95707ef 100644
+--- a/msm8996.c
++++ b/msm8996.c
+@@ -80,6 +80,47 @@ static struct debug_mux mmss_cc = {
+ 	.mux_mask = 0x3ff,
+ };
+ 
++/* rudimentary muxes to enable APC debug clocks */
++static struct debug_mux apc0_mux = {
++	.phys = 0x06400000,
++	.size = 0x1000,
++
++	.enable_reg = 0x48,
++	.enable_mask = 0xf00,
++};
++
++static struct debug_mux apc1_mux = {
++	.phys = 0x06480000,
++	.size = 0x1000,
++
++	.enable_reg = 0x48,
++	.enable_mask = 0xf00,
++};
++
++static void cpu_premeasure(struct debug_mux *mux)
++{
++	mux_enable(&apc0_mux);
++	mux_enable(&apc1_mux);
++};
++
++static void cpu_postmeasure(struct debug_mux *mux)
++{
++	mux_disable(&apc0_mux);
++	mux_disable(&apc1_mux);
++};
++
++static struct debug_mux cpu_cc = {
++	.phys = 0x09820000,
++	.size = 0x1000,
++
++	.mux_reg = 0x78,
++	.mux_mask = 0xff << 8,
++	.mux_shift = 8,
++
++	.premeasure = cpu_premeasure,
++	.postmeasure = cpu_postmeasure,
++};
++
+ static struct measure_clk msm8996_clocks[] = {
+ 	{ "snoc_clk", &gcc, 0x0000 },
+ 	{ "gcc_sys_noc_usb3_axi_clk", &gcc, 0x0006 },
+@@ -270,6 +311,9 @@ static struct measure_clk msm8996_clocks[] = {
+ 	{ "gcc_bimc_gfx_clk", &gcc, 0x00af},
+ 	{ "gcc_hmss_rbcpr_clk", &gcc, 0x00ba },
+ 	//{ "cpu_dbg_clk", &gcc, 0x00bb },
++	{ "cpu_cbf_clk", &gcc, 0x00bb, &cpu_cc, 0x01 },
++	{ "cpu_pwr_clk", &gcc, 0x00bb, &cpu_cc, 0x11, 16 },
++	{ "cpu_perf_clk", &gcc, 0x00bb, &cpu_cc, 0x21, 16 },
+ 	{ "gcc_gp1_clk", &gcc, 0x00e3 },
+ 	{ "gcc_gp2_clk", &gcc, 0x00e4 },
+ 	{ "gcc_gp3_clk", &gcc, 0x00e5 },
+@@ -318,7 +362,19 @@ static struct measure_clk msm8996_clocks[] = {
+ 	{}
+ };
+ 
++static int msm8996_premap(int devmem)
++{
++	if (mmap_mux(devmem, &apc0_mux))
++		return -1;
++
++	if (mmap_mux(devmem, &apc1_mux))
++		return -1;
++
++	return 0;
++}
++
+ struct debugcc_platform msm8996_debugcc = {
+ 	"msm8996",
+ 	msm8996_clocks,
++	msm8996_premap,
+ };
+-- 
+2.35.1
+

--- a/recipes-devtools/debugcc/debugcc_git.bb
+++ b/recipes-devtools/debugcc/debugcc_git.bb
@@ -9,7 +9,7 @@ SRC_URI = "\
     git://github.com/andersson/debugcc.git;branch=master;protocol=https \
 "
 
-SRCREV = "c74b999277c2a18ee05fe6f28af582829039170d"
+SRCREV = "79d8caba44135b7470dddaee3cfb93bd73b89c5e"
 
 PV = "0.0+git${SRCPV}"
 

--- a/recipes-devtools/debugcc/debugcc_git.bb
+++ b/recipes-devtools/debugcc/debugcc_git.bb
@@ -7,6 +7,10 @@ LIC_FILES_CHKSUM = "file://debugcc.c;beginline=5;endline=29;md5=5598b6b886a3af94
 
 SRC_URI = "\
     git://github.com/andersson/debugcc.git;branch=master;protocol=https \
+    file://msm8996/0001-debugcc-preserve-xo_div4-contents.patch \
+    file://msm8996/0002-msm8996-add-support-for-MSM8996-platform.patch \
+    file://msm8996/0003-debugcc-allow-customizing-the-measurement-process.patch \
+    file://msm8996/0004-msm8996-add-support-for-CPU-clocks.patch \
 "
 
 SRCREV = "79d8caba44135b7470dddaee3cfb93bd73b89c5e"

--- a/recipes-devtools/debugcc/debugcc_git.bb
+++ b/recipes-devtools/debugcc/debugcc_git.bb
@@ -7,10 +7,16 @@ LIC_FILES_CHKSUM = "file://debugcc.c;beginline=5;endline=29;md5=5598b6b886a3af94
 
 SRC_URI = "\
     git://github.com/andersson/debugcc.git;branch=master;protocol=https \
+\
+    file://block/0001-debugcc-add-support-for-printing-clocks-from-a-singl.patch \
+    file://block/0002-debugcc-add-block-names-to-all-platforms.patch \
+\
     file://msm8996/0001-debugcc-preserve-xo_div4-contents.patch \
     file://msm8996/0002-msm8996-add-support-for-MSM8996-platform.patch \
     file://msm8996/0003-debugcc-allow-customizing-the-measurement-process.patch \
     file://msm8996/0004-msm8996-add-support-for-CPU-clocks.patch \
+\
+    file://0001-msm8996-add-block-names.patch \
 "
 
 SRCREV = "79d8caba44135b7470dddaee3cfb93bd73b89c5e"


### PR DESCRIPTION
Bring in patches that I use on a daily bases:
- msm8996 support
- filtering of the clock controllers

Corresponding PRs: https://github.com/andersson/debugcc/pull/10, https://github.com/andersson/debugcc/pull/8