### PR TITLE
machine: qcom-armv8a: make sure defaults vars can be overriden

### DIFF
--- a/conf/machine/qcom-armv8a.conf
+++ b/conf/machine/qcom-armv8a.conf
@@ -17,13 +17,13 @@ KERNEL_DEVICETREE ?= " \
     qcom/sm8450-hdk.dtb \
 "
 
-QCOM_BOOTIMG_PAGE_SIZE[apq8016-sbc] = "2048"
-QCOM_BOOTIMG_ROOTFS = "/dev/sda1"
-QCOM_BOOTIMG_ROOTFS[apq8016-sbc] = "/dev/mmcblk0p14"
-QCOM_BOOTIMG_ROOTFS[sm8450-hdk] = "PARTLABEL=userdata"
-SD_QCOM_BOOTIMG_ROOTFS[apq8016-sbc] = "/dev/mmcblk1p7"
-KERNEL_CMDLINE_EXTRA[sdm845-db845c] = "clk_ignore_unused pd_ignore_unused"
-KERNEL_CMDLINE_EXTRA[apq8096-db820c] = "maxcpus=2"
+QCOM_BOOTIMG_PAGE_SIZE[apq8016-sbc] ?= "2048"
+QCOM_BOOTIMG_ROOTFS ?= "/dev/sda1"
+QCOM_BOOTIMG_ROOTFS[apq8016-sbc] ?= "/dev/mmcblk0p14"
+QCOM_BOOTIMG_ROOTFS[sm8450-hdk] ?= "PARTLABEL=userdata"
+SD_QCOM_BOOTIMG_ROOTFS[apq8016-sbc] ?= "/dev/mmcblk1p7"
+KERNEL_CMDLINE_EXTRA[sdm845-db845c] ?= "clk_ignore_unused pd_ignore_unused"
+KERNEL_CMDLINE_EXTRA[apq8096-db820c] ?= "maxcpus=2"
 
 # Userspace tools
 MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \


### PR DESCRIPTION
It is convenient to be able to override the boot image parameters, in local.conf during development, so let's use ?= operator where it was not used.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>