### PR TITLE
linux-qcom-bootimg: Fix SyntaxWarning messages

### DIFF
--- a/recipes-kernel/linux/linux-qcom-bootimg.inc
+++ b/recipes-kernel/linux/linux-qcom-bootimg.inc
@@ -48,9 +48,9 @@ python do_qcom_img_deploy() {
     output_sd_img =  os.path.join(qcom_deploy_dir, "boot-sd-%s.img" % (kernel_link_name))
 
     arch = d.getVar("ARCH")
-    if arch is "arm":
+    if arch == "arm":
         kernel_name = "zImage"
-    elif arch is "arm64":
+    elif arch == "arm64":
         kernel_name = "Image.gz"
     else:
         bb.fatal("Unuspported ARCH %s" % arch)
@@ -108,7 +108,7 @@ python do_qcom_img_deploy() {
                 shutil.copyfileobj(rfd, wfd)
 
         rootfs = getVarDTB("QCOM_BOOTIMG_ROOTFS")
-        if not rootfs or rootfs is "":
+        if not rootfs:
             bb.fatal("QCOM_BOOTIMG_ROOTFS is undefined")
 
         output = make_image("boot-%s-%s.img", rootfs)


### PR DESCRIPTION
Currently linux-qcom-bootimg.inc issues warnings like the following with some versions of Python 3:
```
WARNING: linux-linaro-qcomlt-6.0-r0 do_qcom_img_deploy: .../meta-qcom/recipes-kernel/linux/linux-qcom-bootimg.inc:51: SyntaxWarning: "is" with a literal. Did you mean "=="?
```

Using `is` to test for equality is wrong. `is` only works "by accident" and relies on some rather dubious assumptions about how CPython manages the string literal pool

There are three occurrences, the first two are fixed the obvious way and the final one is simply removed because the code was unreachable anyway (the empty string already evaluates to False when used in a logic expression).

Signed-off-by: Daniel Thompson <daniel.thompson@linaro.org>