### PR TITLE
initramfs-test-image: enable media-ctl and yavta tools

### DIFF
--- a/recipes-test/images/initramfs-test-image.bb
+++ b/recipes-test/images/initramfs-test-image.bb
@@ -51,7 +51,9 @@ PACKAGE_INSTALL_openembedded-layer += " \
     devmem2 \
     lmsensors-config-libsensors \
     lmsensors-sensors \
+    media-ctl \
     read-edid \
+    yavta \
 "
 
 PACKAGE_INSTALL_networking-layer += " \


### PR DESCRIPTION
Enable tools which can be used to test v4l devices on Qualcomm boards. This causes image growth of 419 KiB.

Signed-off-by: Dmitry Baryshkov <dmitry.baryshkov@linaro.org>