### PR TITLE
pulseaudio: remove tsched=0 workaround

### DIFF
--- a/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
+++ b/recipes-multimedia/pulseaudio/pulseaudio_%.bbappend
@@ -1,3 +1,0 @@
-do_install:append:qcom() {
-	sed -i "s|^load-module module-udev-detect|load-module module-udev-detect tsched=0|" ${D}${sysconfdir}/pulse/default.pa
-}


### PR DESCRIPTION
Since 7f2430cda819 (ASoC: qcom: q6asm-dai: Add SNDRV_PCM_INFO_BATCH flag), in the mainline kernel, we no longer need to explicitely disable the timer based scheduling in PA, since the driver correctly reports SNDRV_PCM_INFO_BATCH.

Signed-off-by: Nicolas Dechesne <nicolas.dechesne@linaro.org>