### PR TITLE
mesa: enable tools package

### DIFF
--- a/recipes-graphics/mesa/mesa_%.bbappend
+++ b/recipes-graphics/mesa/mesa_%.bbappend
@@ -3,6 +3,8 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${BPN}:"
 # Enable freedreno driver
 PACKAGECONFIG_FREEDRENO = "\
     freedreno \
+    tools \
+    ${@bb.utils.contains('BBFILE_COLLECTIONS', 'openembedded-layer', 'freedreno-fdperf', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'x11', 'xa', '', d)} \
 "
 


### PR DESCRIPTION
Mesa can provide several tools which simplify debugging mesa and the kernel driver. Enable them to be built into the mesa-tools package.