### PR TITLE
Fix AUTOREV parsing

### DIFF
--- a/recipes-graphics/mesa/mesa_git.bb
+++ b/recipes-graphics/mesa/mesa_git.bb
@@ -7,7 +7,7 @@ SRC_URI = "git://gitlab.freedesktop.org/mesa/mesa.git;protocol=https;branch=main
            "
 LIC_FILES_CHKSUM = "file://docs/license.rst;md5=17a4ea65de7a9ab42437f3131e616a7f"
 
-SRCREV = "${@oe.utils.conditional("MESA_DEV", "1", "${AUTOREV}", "26677008b9a7c0ef82f2a7f4b479d3cb06097c66", d)}"
+SRCREV := "${@oe.utils.conditional("MESA_DEV", "1", "${AUTOREV}", "26677008b9a7c0ef82f2a7f4b479d3cb06097c66", d)}"
 DEFAULT_PREFERENCE = "${@oe.utils.conditional("MESA_DEV", "1", "1", "-1", d)}"
 
 PLATFORMS:remove = "drm surfaceless"

--- a/recipes-kernel/linux/linux-linaro-qcomlt-dev.bb
+++ b/recipes-kernel/linux/linux-linaro-qcomlt-dev.bb
@@ -14,7 +14,7 @@ SRCBRANCH = "integration-linux-qcomlt"
 # hence prevent network access during parsing. If linux-linaro-qcomlt-dev
 # is the preferred provider, they will be overridden to AUTOREV in following
 # anonymous python routine and resolved when the variables are finalized.
-SRCREV ?= '${@oe.utils.conditional("PREFERRED_PROVIDER_virtual/kernel", "linux-linaro-qcomlt-dev", "${AUTOREV}", "29594404d7fe73cd80eaa4ee8c43dcc53970c60e", d)}'
+SRCREV := '${@oe.utils.conditional("PREFERRED_PROVIDER_virtual/kernel", "linux-linaro-qcomlt-dev", "${AUTOREV}", "29594404d7fe73cd80eaa4ee8c43dcc53970c60e", d)}'
 
 LINUX_VERSION = "5.11+"
 PV = "${LINUX_VERSION}+git${SRCPV}"


### PR DESCRIPTION
Fix two errors caused by `AUTOREV` usage:

> ERROR: /home/lumag/Projects/RPB/build-rpb/conf/../../layers/meta-qcom/recipes-graphics/mesa/mesa_git.bb: AUTOREV/SRCPV set too late for the fetcher to work properly, please set the variables earlier in parsing. Erroring instead of later obtuse build failures.
ERROR: /home/lumag/Projects/RPB/build-rpb/conf/../../layers/meta-qcom/recipes-kernel/linux/linux-linaro-qcomlt-dev.bb: AUTOREV/SRCPV set too late for the fetcher to work properly, please set the variables earlier in parsing. Erroring instead of later obtuse build failures.
