### PR TITLE
skales: switch git url to codelinaro

### DIFF
--- a/recipes-devtools/skales/skales_git.bb
+++ b/recipes-devtools/skales/skales_git.bb
@@ -1,6 +1,6 @@
 SUMMARY = "Tools to create boot images for QCOM SoC"
 
-HOMEPAGE = "https://www.codeaurora.org/cgit/quic/kernel/skales/"
+HOMEPAGE = "https://git.codelinaro.org/clo/qsdk/oss/tools/skales"
 SECTION = "devel"
 
 LICENSE = "BSD-3-Clause"
@@ -9,7 +9,7 @@ LIC_FILES_CHKSUM = "file://mkbootimg;beginline=3;endline=29;md5=114b84083e657f38
 SRCREV = "6eac9e943de53c4aaaede3697e9226a47686fe25"
 PV = "1.5.0+git${SRCPV}"
 
-SRC_URI = "git://source.codeaurora.org/quic/kernel/skales;protocol=http;branch=master \
+SRC_URI = "git://git.codelinaro.org/clo/qsdk/oss/tools/skales.git;protocol=https;branch=caf_migration/skales/master \
           file://0002-mkbootimg-use-python3.patch \
           "
 


### PR DESCRIPTION
Skales is still pulling from the now defunct (RIP) codeaurora. Update to point it to codelinaro.